### PR TITLE
Dashboard Repair: Auth Refactor, Event Loop Robustness, and Plot Fixes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,7 +10,12 @@ The backend consists of three main services that work together:
 Flask-based REST API (port 3000) that serves the dashboard, manages kernel configurations, and triggers workflow runs.
 
 ### 2. **Event Loop** (`event_loop.py`)
-Background service that monitors ongoing benchmark runs, provides webhook redundancy, and downloads artifacts.
+Background service composed of three independent handlers:
+- **`run_manager`**: Monitors ongoing runs, updates status, downloads artifacts, reconciles unlinked triggers (idempotent)
+- **`tracker_scheduler`**: Triggers scheduled tracker runs when due (NOT idempotent)
+- **`run_scheduler`**: Dispatches queued triggers to GitHub Actions when machines are available (NOT idempotent)
+
+Supports `--handlers` and `--once` flags for selective execution during local development (see [Local Development](#local-development)).
 
 ### 3. **Webhook Listener** (`listener.py`)
 Pyramid-based service (port 2500) that receives GitHub webhook events for real-time run tracking and PR monitoring.
@@ -232,7 +237,7 @@ All three services must run concurrently:
 # Terminal 1: API Server (port 3000)
 python -m backend.server
 
-# Terminal 2: Event Loop (10s polling)
+# Terminal 2: Event Loop (all handlers, 10s polling)
 python -m backend.event_loop
 
 # Terminal 3: Webhook Listener (port 2500)
@@ -261,6 +266,36 @@ directory=/path/to/backend
 autostart=true
 autorestart=true
 ```
+
+### Local Development
+
+The API server (`server.py`) can safely run locally alongside production since there is no overlap. The event loop requires care because all three handlers share the same Azure Table Storage and GitHub API as the production server. Running the full event loop locally while the production loop is active can cause duplicate workflow dispatches, duplicate trigger linking, and wasted GPU time.
+
+Use the `--handlers` and `--once` flags to run only the handlers you need:
+
+```bash
+# Safe: only run tracking/reconciliation (idempotent)
+python -m backend.event_loop --handlers run_manager
+
+# Single iteration then exit (great for debugging)
+python -m backend.event_loop --handlers run_manager --once
+
+# Test scheduling logic (will create triggers — stop production loop first)
+python -m backend.event_loop --handlers tracker_scheduler --once
+
+# See all options
+python -m backend.event_loop --help
+```
+
+**Handler idempotency reference:**
+
+| Handler | Idempotent? | Safe alongside production? |
+|---|---|---|
+| `run_manager` | Yes — status writes and trigger linking are idempotent | Yes |
+| `tracker_scheduler` | No — creates a new trigger (fresh UUID) each time | No — causes duplicate scheduled runs |
+| `run_scheduler` | Race condition — two processes can dispatch the same queued trigger | Mostly, but can double-dispatch |
+
+**Rule of thumb:** Use `--handlers run_manager` for local testing. Only enable `tracker_scheduler` or `run_scheduler` locally if you have stopped them on the production server first.
 
 ## Configuration
 

--- a/backend/event_loop.py
+++ b/backend/event_loop.py
@@ -1,28 +1,72 @@
+import argparse
+import time
+import traceback
+
 from backend.github_utils import get_repo
 from backend.runs.manager import RunManager
 from backend.runs.scheduling import TrackerScheduler, RunScheduler
-import time
-import traceback
 
 UPDATE_RUNS_INTERVAL = 10  # seconds
 CHECK_TRACKERS_INTERVAL = 60  # seconds (check every minute)
 CHECK_QUEUE_INTERVAL = 30  # seconds (check every 30 seconds)
 
+ALL_HANDLERS = ["run_manager", "tracker_scheduler", "run_scheduler"]
+
 repo = get_repo("bench")
 
 
-def serve_event_loop():
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Backend event loop with optional handler selection.",
+        epilog=(
+            "Examples:\n"
+            "  python -m backend.event_loop                          # all handlers (production)\n"
+            "  python -m backend.event_loop --handlers run_manager   # only run tracking/reconciliation\n"
+            "  python -m backend.event_loop --once                   # single iteration then exit\n"
+            "  python -m backend.event_loop --handlers run_manager --once\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--handlers",
+        nargs="+",
+        choices=ALL_HANDLERS,
+        default=ALL_HANDLERS,
+        metavar="HANDLER",
+        help=(
+            "Which handlers to enable (default: all). Choices: "
+            "run_manager (status updates + trigger reconciliation), "
+            "tracker_scheduler (scheduled tracker runs), "
+            "run_scheduler (dispatch queued triggers)."
+        ),
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run one iteration of each enabled handler then exit.",
+    )
+    return parser.parse_args()
+
+
+def serve_event_loop(handlers=None, once=False):
+    if handlers is None:
+        handlers = ALL_HANDLERS
+    enabled = set(handlers)
+
+    print(f"Event loop starting | handlers={sorted(enabled)} | once={once}")
+
     last_run_update_time = 0
     last_tracker_check_time = 0
     last_queue_check_time = 0
-    run_manager = RunManager()
-    tracker_scheduler = TrackerScheduler()
-    run_scheduler = RunScheduler()
+
+    run_manager = RunManager() if "run_manager" in enabled else None
+    tracker_scheduler = TrackerScheduler() if "tracker_scheduler" in enabled else None
+    run_scheduler = RunScheduler() if "run_scheduler" in enabled else None
 
     while True:
         now = time.time()
 
-        if now - last_run_update_time >= UPDATE_RUNS_INTERVAL:
+        if run_manager and now - last_run_update_time >= UPDATE_RUNS_INTERVAL:
             try:
                 run_manager.update_runs()
             except Exception:
@@ -30,7 +74,7 @@ def serve_event_loop():
                 traceback.print_exc()
             last_run_update_time = now
 
-        if now - last_tracker_check_time >= CHECK_TRACKERS_INTERVAL:
+        if tracker_scheduler and now - last_tracker_check_time >= CHECK_TRACKERS_INTERVAL:
             try:
                 tracker_scheduler.check_and_trigger_due_trackers()
             except Exception:
@@ -38,7 +82,7 @@ def serve_event_loop():
                 traceback.print_exc()
             last_tracker_check_time = now
 
-        if now - last_queue_check_time >= CHECK_QUEUE_INTERVAL:
+        if run_scheduler and now - last_queue_check_time >= CHECK_QUEUE_INTERVAL:
             try:
                 run_scheduler.check_and_dispatch_queued_runs()
             except Exception:
@@ -46,8 +90,13 @@ def serve_event_loop():
                 traceback.print_exc()
             last_queue_check_time = now
 
+        if once:
+            print("Single iteration complete, exiting.")
+            break
+
         time.sleep(1)
 
 
 if __name__ == "__main__":
-    serve_event_loop()
+    args = parse_args()
+    serve_event_loop(handlers=args.handlers, once=args.once)

--- a/backend/runs/README.md
+++ b/backend/runs/README.md
@@ -287,6 +287,15 @@ manager = RunManager()
 manager.update_runs()  # Poll GitHub and download artifacts
 ```
 
+To test run monitoring locally without conflicting with the production event loop, use the `--handlers` flag to run only the idempotent `run_manager` handler:
+
+```bash
+python -m backend.event_loop --handlers run_manager        # continuous
+python -m backend.event_loop --handlers run_manager --once  # single iteration
+```
+
+See [backend/README.md](../README.md#local-development) for the full handler idempotency reference.
+
 ### Querying Runs
 
 ```python

--- a/backend/runs/manager.py
+++ b/backend/runs/manager.py
@@ -3,11 +3,11 @@ from typing import List, Optional
 
 from backend.github_utils.auth import get_repo
 from backend.runs import RunType
-from backend.runs.run_utils import find_incomplete_runs
+from backend.runs.run_utils import find_incomplete_runs, parse_run_from_gh
 from backend.runs.tracker import get_run_tracker
 from backend.storage.auth import get_blob_client
 from backend.storage.triggers import RunTriggerDb, TriggerStatus, link_trigger_to_run
-from backend.storage.types import WorkflowRunState
+from backend.storage.types import WorkflowRunDb, WorkflowRunState
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,8 @@ class RunManager:
         
         This is the backup mechanism for when webhook events are missed.
         It queries GitHub for recent runs and tries to match them to unlinked triggers.
+        When a match is found, it ensures a WorkflowRunState exists in the database
+        so the run can be tracked and artifacts can be downloaded.
         """
         try:
             # Find triggers that have been dispatched but not linked
@@ -91,13 +93,16 @@ class RunManager:
                         logger.info(f"Found matching run {gh_run.id} for trigger {trigger_id}")
                         run_id = str(gh_run.id)
                         
+                        # Ensure WorkflowRunState exists in the database.
+                        # When webhooks are missed, this is the only path that
+                        # creates the run record needed for tracking & artifacts.
+                        self._ensure_workflow_run_exists(gh_run, trigger)
+                        
                         # Link trigger to run
                         if link_trigger_to_run(trigger_id, run_id):
-                            # Also update the WorkflowRunState if it exists
                             try:
-                                from backend.storage.types import WorkflowRunDb
                                 WorkflowRunDb.update_by_id(run_id, {"triggerId": trigger_id})
-                            except:
+                            except Exception:
                                 pass
                             
                             linked_count += 1
@@ -108,6 +113,31 @@ class RunManager:
                 
         except Exception as e:
             logger.error(f"Error during trigger reconciliation: {e}")
+    
+    def _ensure_workflow_run_exists(self, gh_run, trigger):
+        """
+        Create a WorkflowRunState in the database if one doesn't already exist.
+        
+        This is critical for the backup reconciliation path: when webhooks are
+        missed, the WorkflowRunState is never created, so the event loop can't
+        track the run or download artifacts. This method fills that gap.
+        """
+        run_id = str(gh_run.id)
+        existing = WorkflowRunDb.find_by_id(run_id)
+        if existing:
+            return
+        
+        try:
+            run = parse_run_from_gh(gh_run)
+            run.triggerId = trigger._id
+            run.machine = trigger.machine
+            WorkflowRunDb.upsert(run)
+            logger.info(
+                f"Created WorkflowRunState for run {run_id} "
+                f"(status={run.status}, conclusion={run.conclusion})"
+            )
+        except Exception as e:
+            logger.error(f"Failed to create WorkflowRunState for run {run_id}: {e}")
     
     def _extract_trigger_id_from_run(self, gh_run) -> Optional[str]:
         """

--- a/backend/runs/parsing/bench_parser.py
+++ b/backend/runs/parsing/bench_parser.py
@@ -104,7 +104,7 @@ class BenchmarkArtifactParser(RunArtifactParser):
             stats = BenchmarkRunStats(
                 _id=str(uuid4()),
                 runId=run_id,
-                timestamp=datetime.now(timezone.utc),
+                timestamp=run.timestamp,
                 machine=run.machine,
                 performance=performance,
                 trackerId=tracker_id,

--- a/backend/runs/scheduling/README.md
+++ b/backend/runs/scheduling/README.md
@@ -421,6 +421,33 @@ if upcoming:
 
 ## Testing Considerations
 
+### Local Development with `--handlers`
+
+The event loop supports selective handler execution to avoid conflicts with the production event loop. Both instances share the same Azure Table Storage and GitHub API, so running all handlers locally alongside production will cause duplicate dispatches and wasted resources.
+
+```bash
+# Safe: only run_manager (idempotent — status updates + trigger reconciliation)
+python -m backend.event_loop --handlers run_manager
+
+# Single iteration for debugging
+python -m backend.event_loop --handlers run_manager --once
+
+# Test scheduling logic only (stop production loop first!)
+python -m backend.event_loop --handlers tracker_scheduler run_scheduler --once
+```
+
+**Handler idempotency:**
+
+| Handler | Idempotent? | Why |
+|---|---|---|
+| `run_manager` | Yes | Status writes overwrite with same data; `link_trigger_to_run` is a no-op if already linked; `_ensure_workflow_run_exists` checks before creating |
+| `tracker_scheduler` | No | Creates a new `RunTrigger` with a fresh UUID each invocation; in-memory dedup (`_last_triggered`) is per-process |
+| `run_scheduler` | Race condition | Two processes can query the same `QUEUED` trigger before either flips it to `DISPATCHED`, causing a double-dispatch |
+
+**Rule of thumb:** Use `--handlers run_manager` for local testing. Only enable `tracker_scheduler` or `run_scheduler` locally after stopping them on production.
+
+### General Testing Guidelines
+
 When testing the scheduler:
 
 1. **Time-based tests:** Use fixed datetimes instead of `datetime.now()` to avoid flaky tests

--- a/backend/server.py
+++ b/backend/server.py
@@ -16,14 +16,14 @@ from backend.webhook.wave_update import WaveUpdateListener
 from backend.storage.auth import get_blob_client
 
 from uuid import uuid4
-from flask import Flask, jsonify, request, make_response
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 from dataclass_wizard import fromdict, asdict
 from functools import wraps
 import jwt
 from datetime import datetime, timezone, timedelta
 import os
-from werkzeug.security import check_password_hash, generate_password_hash
+from werkzeug.security import check_password_hash
 from dotenv import load_dotenv
 
 directory_client = get_blob_client()
@@ -135,19 +135,24 @@ def home():
     return jsonify({"message": "Flask server with CORS is running on port 3000."})
 
 
+def _extract_bearer_token():
+    """Extract JWT from the Authorization header."""
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        return auth_header[7:]
+    return None
+
+
 def token_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        token = request.headers.get("Authorization")
+        token = _extract_bearer_token()
 
         if not token:
-            return jsonify({"message": "Token is missing"}), 401
+            return jsonify({"message": "Authentication required"}), 401
 
         try:
-            if token.startswith("Bearer "):
-                token = token[7:]
-
-            data = jwt.decode(token, app.config["SECRET_KEY"], algorithms=["HS256"])
+            jwt.decode(token, app.config["SECRET_KEY"], algorithms=["HS256"])
         except jwt.ExpiredSignatureError:
             return jsonify({"message": "Token has expired"}), 401
         except jwt.InvalidTokenError:
@@ -168,28 +173,18 @@ def login():
 
     if check_password_hash(app.config["PASSWORD_HASH"], password):
         token = jwt.encode(
-            {"exp": datetime.now(timezone.utc) + timedelta(minutes=30)},
+            {"exp": datetime.now(timezone.utc) + timedelta(hours=24)},
             app.config["SECRET_KEY"],
             algorithm="HS256",
         )
-
-        response = make_response(jsonify({"message": "Login successful"}))
-        response.set_cookie(
-            "auth_token",
-            token,
-            max_age=30 * 60,
-            httponly=True,
-            secure=True,
-            samesite="Lax",
-        )
-        return response
+        return jsonify({"message": "Login successful", "token": token})
 
     return jsonify({"message": "Invalid password"}), 401
 
 
 @app.route("/auth/verify", methods=["GET"])
 def verify():
-    token = request.cookies.get("auth_token")
+    token = _extract_bearer_token()
 
     if not token:
         return jsonify({"authenticated": False}), 200
@@ -203,9 +198,7 @@ def verify():
 
 @app.route("/auth/logout", methods=["POST"])
 def logout():
-    response = make_response(jsonify({"message": "Logout successful"}))
-    response.set_cookie("auth_token", "", expires=0)
-    return response
+    return jsonify({"message": "Logout successful"})
 
 
 @app.route("/pull_requests")
@@ -360,7 +353,7 @@ def get_runs():
 
 
 @app.route("/api/runs/<run_id>", methods=["DELETE"])
-# @token_required
+@token_required
 def delete_run(run_id):
     """Delete a workflow run, its artifact, and its trigger."""
     try:
@@ -412,6 +405,7 @@ def get_artifact_by_run_id(blob_name):
 
 
 @app.route("/workflow/pr/trigger", methods=["POST"])
+@token_required
 def trigger_pr_workflow():
     """Trigger a benchmark workflow for a pull request."""
     response_data = request.get_json()
@@ -460,6 +454,7 @@ def trigger_pr_workflow():
 
 
 @app.route("/workflow/manual/trigger", methods=["POST"])
+@token_required
 def trigger_manual_workflow():
     """Trigger a manual benchmark workflow."""
     response_data = request.get_json()
@@ -539,6 +534,7 @@ def trigger_manual_workflow():
 
 
 @app.route("/workflow/cancel", methods=["POST"])
+@token_required
 def cancel_workflow():
     payload = request.get_json()
     run_id = int(payload["runId"])
@@ -550,6 +546,7 @@ def cancel_workflow():
 
 
 @app.route("/rebase", methods=["POST"])
+@token_required
 def rebase_prs():
     # rebase_all()
     rebase_pull_requests()
@@ -565,6 +562,7 @@ def rebase_prs():
 
 
 @app.route("/tune", methods=["POST"])
+@token_required
 def tune_kernels():
     payload = request.get_json()
     kernel_ids = [str(id) for id in payload["kernel_ids"]]
@@ -660,7 +658,7 @@ def get_all_kernel_types():
 
 
 @app.route("/kernel_types", methods=["POST"])
-# @token_required
+@token_required
 def add_kernel_type():
     """Add a new kernel type to the database."""
     try:
@@ -694,7 +692,7 @@ def add_kernel_type():
 
 
 @app.route("/kernel_types/<kernel_type_id>", methods=["PUT"])
-# @token_required
+@token_required
 def update_kernel_type(kernel_type_id):
     """Update an existing kernel type."""
     try:
@@ -718,7 +716,7 @@ def update_kernel_type(kernel_type_id):
 
 
 @app.route("/kernel_types/<kernel_type_id>", methods=["DELETE"])
-# @token_required
+@token_required
 def remove_kernel_type(kernel_type_id):
     """Remove a kernel type from the database."""
     try:
@@ -747,7 +745,7 @@ def get_all_kernels():
 
 
 @app.route("/kernels", methods=["POST"])
-# @token_required
+@token_required
 def add_kernels():
     """Add multiple new kernel configurations to the database."""
     try:
@@ -800,7 +798,7 @@ def add_kernels():
 
 
 @app.route("/kernels/<kernel_id>", methods=["PUT"])
-# @token_required
+@token_required
 def update_kernel(kernel_id):
     """Update an existing kernel configuration."""
     try:
@@ -825,7 +823,7 @@ def update_kernel(kernel_id):
 
 
 @app.route("/kernels/batch", methods=["PUT"])
-# @token_required
+@token_required
 def update_kernels_batch():
     """Update multiple kernel configurations using batched transactions."""
     try:
@@ -872,7 +870,7 @@ def update_kernels_batch():
 
 
 @app.route("/kernels", methods=["DELETE"])
-# @token_required
+@token_required
 def remove_kernels():
     """Remove multiple kernel configurations from the database."""
     try:
@@ -932,7 +930,7 @@ def get_trackers():
 
 
 @app.route("/api/trackers", methods=["POST"])
-# @token_required
+@token_required
 def create_tracker():
     """Create a new tracker."""
     try:
@@ -1015,7 +1013,7 @@ def create_tracker():
 
 
 @app.route("/api/trackers/<tracker_id>", methods=["PUT"])
-# @token_required
+@token_required
 def update_tracker(tracker_id):
     """Update an existing tracker."""
     try:
@@ -1113,7 +1111,7 @@ def update_tracker(tracker_id):
 
 
 @app.route("/api/trackers/<tracker_id>", methods=["DELETE"])
-# @token_required
+@token_required
 def delete_tracker(tracker_id):
     """Delete a tracker."""
     try:
@@ -1136,7 +1134,7 @@ def delete_tracker(tracker_id):
 
 
 @app.route("/api/trackers/<tracker_id>/trigger", methods=["POST"])
-# @token_required
+@token_required
 def trigger_tracker_manually(tracker_id):
     """Manually trigger a tracker run before its scheduled time."""
     try:

--- a/dashboard/src/components/DashboardSections/DashboardPerformanceSection.tsx
+++ b/dashboard/src/components/DashboardSections/DashboardPerformanceSection.tsx
@@ -31,38 +31,54 @@ export default function DashboardPerformanceSection({
   const [graphType, setGraphType] = useState<string>("bar");
   const [comparisonMetric, setComparisonMetric] = useState<string>("tflops");
   const [percentile, setPercentile] = useState<number>(90);
-  const [trackerBackendSpecs, setTrackerBackendSpecs] = useState<Record<string, BackendSpec>>({});
+  const [trackerBackendSpecs, setTrackerBackendSpecs] = useState<
+    Record<string, BackendSpec>
+  >({});
 
   const kernelDims = useKernelDims();
   // Use the filter hook
-  const { filters, availableOptions, filteredKernels, updateFilter, filterConfigs } =
-    useKernelFilters(kernels);
-  
+  const {
+    filters,
+    availableOptions,
+    filteredKernels,
+    updateFilter,
+    filterConfigs,
+  } = useKernelFilters(kernels);
+
   // Determine which backend specs to use: prop (from run) or tracker (fetched)
   const latestBackendSpecs = propBackendSpecs || trackerBackendSpecs;
-  
+
   // Fetch backend specs from tracker if trackerId is provided
   useEffect(() => {
     const fetchTrackerBackendSpecs = async () => {
       if (!trackerId) return;
-      
+
       try {
         const response = await fetch(
-          `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}/performance`
+          `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}/performance`,
         );
         const timeline = await response.json();
-        
+
         if (timeline.length > 0) {
           // Find the latest point that has backendSpecs, fallback to last point
-          const latestPoint = [...timeline].reverse().find(point => 
-            point.backendSpecs && Array.isArray(point.backendSpecs) && point.backendSpecs.length > 0
-          ) || timeline[timeline.length - 1];
-          
+          const latestPoint =
+            [...timeline]
+              .reverse()
+              .find(
+                (point) =>
+                  point.backendSpecs &&
+                  Array.isArray(point.backendSpecs) &&
+                  point.backendSpecs.length > 0,
+              ) || timeline[timeline.length - 1];
+
           console.log("Timeline points:", timeline.length);
           console.log("Latest point with specs:", latestPoint);
           console.log("Latest point backendSpecs:", latestPoint.backendSpecs);
-          
-          if (latestPoint.backendSpecs && Array.isArray(latestPoint.backendSpecs)) {
+
+          if (
+            latestPoint.backendSpecs &&
+            Array.isArray(latestPoint.backendSpecs)
+          ) {
             // Convert array to Record<backend, spec>
             // Use backendParam as key if available (e.g., wave_4wave), otherwise use backend
             const specsMap: Record<string, BackendSpec> = {};
@@ -77,13 +93,13 @@ export default function DashboardPerformanceSection({
         console.error("Failed to fetch tracker backend specs:", error);
       }
     };
-    
+
     fetchTrackerBackendSpecs();
   }, [trackerId]);
 
   const selectedKernel = useMemo(
     () => kernels.find((k) => k.id === selectedKernelId),
-    [kernels, selectedKernelId]
+    [kernels, selectedKernelId],
   );
 
   const sameShapeKernels = useMemo(() => {
@@ -91,16 +107,15 @@ export default function DashboardPerformanceSection({
     const dims = getDimensionsForKernelType(
       selectedKernel.kernelType,
       kernelDims,
-      selectedKernel.shape
+      selectedKernel.shape,
     );
     return kernels.filter((k) => {
       if (k.kernelType !== selectedKernel.kernelType) return false;
       if (k.dtype !== selectedKernel.dtype) return false;
-      return dims.every(
-        (dimName) =>
-          (dimName === "dtype"
-            ? k.dtype === selectedKernel.dtype
-            : k.shape[dimName] === selectedKernel.shape[dimName])
+      return dims.every((dimName) =>
+        dimName === "dtype"
+          ? k.dtype === selectedKernel.dtype
+          : k.shape[dimName] === selectedKernel.shape[dimName],
       );
     });
   }, [kernels, selectedKernel, kernelDims]);
@@ -109,9 +124,9 @@ export default function DashboardPerformanceSection({
     () =>
       filterKernelsByPercentile(
         getCommonKernels(filteredKernels, kernelDims),
-        Math.min(Math.max(percentile / 100, 0), 1)
+        Math.min(Math.max(percentile / 100, 0), 1),
       ),
-    [filteredKernels, percentile, kernelDims]
+    [filteredKernels, percentile, kernelDims],
   );
 
   if (isLoading) {
@@ -156,18 +171,15 @@ export default function DashboardPerformanceSection({
               <TrendingUp className="w-12 h-12 mb-3 text-gray-300" />
               <p className="text-lg font-medium">No Common Kernels Found</p>
               <p className="text-sm text-center">
-                Try adjusting your filters to see results on the roofline
-                plot.
+                Try adjusting your filters to see results on the roofline plot.
               </p>
             </div>
           ) : (
-            <div className="flex justify-center">
-              <RooflinePlot
-                kernels={commonKernels}
-                setSelected={setSelectedKernelId}
-                selectedKernel={selectedKernel}
-              />
-            </div>
+            <RooflinePlot
+              kernels={commonKernels}
+              setSelected={setSelectedKernelId}
+              selectedKernel={selectedKernel}
+            />
           )}
         </div>
 
@@ -209,9 +221,7 @@ export default function DashboardPerformanceSection({
                   <select
                     className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none text-sm"
                     value={comparisonMetric}
-                    onChange={(e) =>
-                      setComparisonMetric(e.currentTarget.value)
-                    }
+                    onChange={(e) => setComparisonMetric(e.currentTarget.value)}
                   >
                     <option value="tflops">TFLOPs</option>
                     <option value="runtime">Runtime (μs)</option>
@@ -261,24 +271,16 @@ export default function DashboardPerformanceSection({
                 Adjust your filters to see performance comparison data.
               </p>
             </div>
+          ) : graphType === "bar" || selectedKernelId ? (
+            <BarComparisonPlot
+              kernels={selectedKernelId ? sameShapeKernels : commonKernels}
+              metric={comparisonMetric}
+            />
           ) : (
-            <div className="flex justify-center">
-              {graphType === "bar" || selectedKernelId ? (
-                <BarComparisonPlot
-                  kernels={
-                    selectedKernelId ? sameShapeKernels : commonKernels
-                  }
-                  metric={comparisonMetric}
-                />
-              ) : (
-                <BellComparisonPlot
-                  kernels={
-                    selectedKernelId ? sameShapeKernels : commonKernels
-                  }
-                  metric={comparisonMetric}
-                />
-              )}
-            </div>
+            <BellComparisonPlot
+              kernels={selectedKernelId ? sameShapeKernels : commonKernels}
+              metric={comparisonMetric}
+            />
           )}
         </div>
       </div>
@@ -293,7 +295,7 @@ export default function DashboardPerformanceSection({
             dimensions={getDimensionsForKernelType(
               selectedKernel.kernelType,
               kernelDims,
-              selectedKernel.shape
+              selectedKernel.shape,
             )}
           />
         </div>

--- a/dashboard/src/components/DayTimeline.tsx
+++ b/dashboard/src/components/DayTimeline.tsx
@@ -1,0 +1,385 @@
+import { useState, useEffect, useMemo } from "react";
+import { Clock, Monitor } from "lucide-react";
+import type { ScheduleData } from "../utils/github";
+
+interface TrackerInfo {
+  id: string;
+  name: string;
+  machine: string;
+  isActive: boolean;
+  schedule: ScheduleData;
+  tags: string[];
+}
+
+interface ScheduledRun {
+  tracker: TrackerInfo;
+  hour: number;
+  minute: number;
+}
+
+const COLORS = [
+  "#3B82F6",
+  "#10B981",
+  "#F59E0B",
+  "#8B5CF6",
+  "#06B6D4",
+  "#EC4899",
+  "#84CC16",
+  "#F97316",
+];
+
+const HOUR_MARKS = [0, 3, 6, 9, 12, 15, 18, 21, 24];
+const TOTAL_MINUTES = 1440;
+const ESTIMATED_DURATION_MINUTES = 120;
+
+function normalizeDay(day: string): string {
+  const d = day.trim();
+  const title = d.charAt(0).toUpperCase() + d.slice(1).toLowerCase();
+  const abbrevMap: Record<string, string> = {
+    Mon: "Monday",
+    Tue: "Tuesday",
+    Wed: "Wednesday",
+    Thu: "Thursday",
+    Fri: "Friday",
+    Sat: "Saturday",
+    Sun: "Sunday",
+  };
+  return abbrevMap[title] || title;
+}
+
+function parseMMDDYYYY(dateStr: string): Date {
+  const [month, day, year] = dateStr.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function getScheduledRunsToday(trackers: TrackerInfo[]): ScheduledRun[] {
+  const now = new Date();
+  const todayUTC = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  const dayNames = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  const todayDayName = dayNames[todayUTC.getUTCDay()];
+  const runs: ScheduledRun[] = [];
+
+  for (const tracker of trackers) {
+    if (!tracker.isActive) continue;
+
+    const schedule = tracker.schedule;
+    if (!schedule?.timeOfDay) continue;
+
+    const [hour, minute] = schedule.timeOfDay.split(":").map(Number);
+
+    if (schedule.startDate) {
+      const startDate = parseMMDDYYYY(schedule.startDate);
+      if (todayUTC < startDate) continue;
+    }
+
+    if (schedule.endDate) {
+      const endDate = parseMMDDYYYY(schedule.endDate);
+      if (todayUTC > endDate) continue;
+    }
+
+    let runsToday = false;
+
+    if (!schedule.isInterval) {
+      const normalizedDays = (schedule.daysOfWeek || []).map(normalizeDay);
+      runsToday = normalizedDays.includes(todayDayName);
+    } else {
+      const startDate = parseMMDDYYYY(schedule.startDate);
+      let intervalDays: number;
+      if (schedule.intervalUnit === "months") {
+        intervalDays = (schedule.intervalValue || 1) * 30;
+      } else {
+        intervalDays = (schedule.intervalValue || 1) * 7;
+      }
+
+      const daysSinceStart = Math.floor(
+        (todayUTC.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
+      );
+      runsToday = daysSinceStart >= 0 && daysSinceStart % intervalDays === 0;
+    }
+
+    if (runsToday) {
+      runs.push({ tracker, hour, minute });
+    }
+  }
+
+  return runs.sort((a, b) => a.hour * 60 + a.minute - (b.hour * 60 + b.minute));
+}
+
+function formatTime(hour: number, minute: number): string {
+  return `${hour.toString().padStart(2, "0")}:${minute.toString().padStart(2, "0")}`;
+}
+
+function getNowMinutesUTC(): number {
+  const now = new Date();
+  return now.getUTCHours() * 60 + now.getUTCMinutes();
+}
+
+export default function DayTimeline({
+  trackers,
+}: {
+  trackers: TrackerInfo[];
+}) {
+  const [nowMinutes, setNowMinutes] = useState(getNowMinutesUTC);
+
+  useEffect(() => {
+    const interval = setInterval(() => setNowMinutes(getNowMinutesUTC()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const scheduledRuns = useMemo(() => getScheduledRunsToday(trackers), [trackers]);
+
+  const machineGroups = useMemo(() => {
+    const groups: Record<string, ScheduledRun[]> = {};
+    for (const run of scheduledRuns) {
+      const m = run.tracker.machine;
+      if (!groups[m]) groups[m] = [];
+      groups[m].push(run);
+    }
+    return groups;
+  }, [scheduledRuns]);
+
+  const trackerColorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    let i = 0;
+    for (const t of trackers) {
+      if (!map[t.id]) {
+        map[t.id] = COLORS[i % COLORS.length];
+        i++;
+      }
+    }
+    return map;
+  }, [trackers]);
+
+  const machines = Object.keys(machineGroups).sort();
+  const nowPercent = Math.min(100, Math.max(0, (nowMinutes / TOTAL_MINUTES) * 100));
+  const nowHour = Math.floor(nowMinutes / 60);
+  const nowMinute = nowMinutes % 60;
+
+  const dateStr = new Date().toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  if (scheduledRuns.length === 0) {
+    return (
+      <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Clock className="w-5 h-5 text-gray-400" />
+            <h2 className="text-lg font-semibold text-gray-900">
+              Today's Schedule
+            </h2>
+          </div>
+          <span className="text-sm text-gray-500">{dateStr} (UTC)</span>
+        </div>
+        <p className="text-gray-500 text-sm mt-3">
+          No active trackers are scheduled to run today.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-2">
+          <Clock className="w-5 h-5 text-blue-600" />
+          <h2 className="text-lg font-semibold text-gray-900">
+            Today's Schedule
+          </h2>
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-gray-500">{dateStr}</span>
+          <span className="flex items-center gap-1.5 text-sm font-medium text-red-600">
+            <span className="w-1.5 h-1.5 bg-red-500 rounded-full animate-pulse" />
+            {formatTime(nowHour, nowMinute)} UTC
+          </span>
+        </div>
+      </div>
+
+      {/* Machine timelines */}
+      <div className="space-y-5">
+        {machines.map((machine) => {
+          const runs = machineGroups[machine];
+          return (
+            <div key={machine}>
+              {/* Machine label */}
+              <div className="flex items-center gap-1.5 mb-2">
+                <Monitor className="w-3.5 h-3.5 text-gray-400" />
+                <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  {machine}
+                </span>
+              </div>
+
+              {/* Timeline track */}
+              <div className="relative h-10 bg-gray-50 rounded-lg border border-gray-100">
+                {/* Elapsed portion */}
+                <div
+                  className="absolute inset-y-0 left-0 bg-gray-100/70 rounded-l-lg"
+                  style={{ width: `${nowPercent}%` }}
+                />
+
+                {/* Hour gridlines */}
+                {HOUR_MARKS.slice(1, -1).map((h) => (
+                  <div
+                    key={h}
+                    className="absolute top-0 bottom-0 w-px bg-gray-200/70"
+                    style={{ left: `${(h / 24) * 100}%` }}
+                  />
+                ))}
+
+                {/* Scheduled run intervals */}
+                {runs.map((run, idx) => {
+                  const startMin = run.hour * 60 + run.minute;
+                  const endMin = startMin + ESTIMATED_DURATION_MINUTES;
+                  const startPct = (startMin / TOTAL_MINUTES) * 100;
+                  const endPct =
+                    (Math.min(endMin, TOTAL_MINUTES) / TOTAL_MINUTES) * 100;
+                  const widthPct = endPct - startPct;
+                  const color = trackerColorMap[run.tracker.id];
+
+                  const endHour = Math.floor(endMin / 60);
+                  const endMinute = endMin % 60;
+
+                  let status: "completed" | "in_progress" | "upcoming";
+                  if (endMin <= nowMinutes) status = "completed";
+                  else if (startMin <= nowMinutes) status = "in_progress";
+                  else status = "upcoming";
+
+                  return (
+                    <div
+                      key={`${run.tracker.id}-${idx}`}
+                      className="absolute top-1 bottom-1 rounded-md group z-10 cursor-default transition-opacity"
+                      style={{
+                        left: `${startPct}%`,
+                        width: `${widthPct}%`,
+                        backgroundColor: color,
+                        opacity:
+                          status === "completed"
+                            ? 0.35
+                            : status === "in_progress"
+                              ? 1
+                              : 0.75,
+                      }}
+                    >
+                      {/* In-progress pulsing border */}
+                      {status === "in_progress" && (
+                        <div
+                          className="absolute inset-0 rounded-md border-2 animate-pulse"
+                          style={{ borderColor: color }}
+                        />
+                      )}
+
+                      {/* Label inside bar */}
+                      <div className="absolute inset-0 flex items-center px-2 overflow-hidden">
+                        <span className="text-[10px] font-semibold text-white truncate drop-shadow-sm">
+                          {run.tracker.name}
+                        </span>
+                      </div>
+
+                      {/* Tooltip */}
+                      <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-30 min-w-max">
+                        <div className="bg-gray-900 text-white text-xs rounded-lg px-3 py-2 shadow-xl">
+                          <p className="font-semibold">{run.tracker.name}</p>
+                          <p className="text-gray-300 mt-0.5">
+                            {formatTime(run.hour, run.minute)} –{" "}
+                            {formatTime(endHour, endMinute)} UTC
+                            {status === "completed"
+                              ? " (completed)"
+                              : status === "in_progress"
+                                ? " (in progress)"
+                                : ""}
+                          </p>
+                          {run.tracker.tags.length > 0 && (
+                            <p className="text-gray-400 mt-1">
+                              {run.tracker.tags.join(", ")}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex justify-center -mt-1">
+                          <div className="w-2 h-2 bg-gray-900 rotate-45" />
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+
+                {/* Now indicator */}
+                <div
+                  className="absolute top-0 bottom-0 z-20 pointer-events-none"
+                  style={{ left: `${nowPercent}%` }}
+                >
+                  <div className="absolute inset-y-0 w-0.5 bg-red-500 -translate-x-1/2" />
+                  <div className="absolute -top-px left-1/2 -translate-x-1/2">
+                    <div className="w-0 h-0 border-l-[4px] border-r-[4px] border-t-[5px] border-l-transparent border-r-transparent border-t-red-500" />
+                  </div>
+                  <div className="absolute -bottom-px left-1/2 -translate-x-1/2">
+                    <div className="w-0 h-0 border-l-[4px] border-r-[4px] border-b-[5px] border-l-transparent border-r-transparent border-b-red-500" />
+                  </div>
+                </div>
+              </div>
+
+              {/* Run legend for this machine */}
+              <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                {runs.map((run, idx) => {
+                  const startMin = run.hour * 60 + run.minute;
+                  const endMin = startMin + ESTIMATED_DURATION_MINUTES;
+                  const endHour = Math.floor(endMin / 60);
+                  const endMinute = endMin % 60;
+                  const color = trackerColorMap[run.tracker.id];
+                  const isPast = endMin <= nowMinutes;
+                  return (
+                    <div
+                      key={`legend-${run.tracker.id}-${idx}`}
+                      className="flex items-center gap-1.5"
+                      style={{ opacity: isPast ? 0.5 : 1 }}
+                    >
+                      <div
+                        className="w-3 h-2 rounded-sm flex-shrink-0"
+                        style={{ backgroundColor: color }}
+                      />
+                      <span className="text-xs font-medium text-gray-700">
+                        {run.tracker.name}
+                      </span>
+                      <span className="text-xs text-gray-400">
+                        {formatTime(run.hour, run.minute)} –{" "}
+                        {formatTime(endHour, endMinute)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Shared hour labels */}
+      <div className="relative h-5 mt-4 mx-0">
+        {HOUR_MARKS.map((h) => (
+          <span
+            key={h}
+            className="absolute text-[10px] text-gray-400 -translate-x-1/2 select-none"
+            style={{ left: `${(h / 24) * 100}%` }}
+          >
+            {h === 24 ? "" : `${h}:00`}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/Navbar.tsx
+++ b/dashboard/src/components/Navbar.tsx
@@ -1,10 +1,8 @@
-// Navbar.tsx
-import React, { useState } from "react";
+import React from "react";
 import { Home, History, Plus, Zap, Lock, ListChecks, CalendarDays } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { twMerge } from "tailwind-merge";
 import { useAuth } from "../contexts/AuthContext";
-import PasswordModal from "./PasswordModal";
 
 export type PageName = "dashboard" | "history" | "runs" | "new" | "kernels" | "tracking";
 
@@ -59,106 +57,89 @@ const navItems: NavItemProps[] = [
 ];
 
 const Navbar: React.FC<NavbarProps> = ({ activePage }) => {
-  const { isAuthenticated, login } = useAuth();
+  const { isAuthenticated, requestAuth, logout } = useAuth();
   const navigate = useNavigate();
-  const [showPasswordModal, setShowPasswordModal] = useState(false);
-  const [pendingNavigation, setPendingNavigation] = useState<PageName | null>(
-    null
-  );
 
-  const handleNavClick = (e: React.MouseEvent, item: NavItemProps) => {
+  const handleNavClick = async (e: React.MouseEvent, item: NavItemProps) => {
     if (item.requireAuth && !isAuthenticated) {
       e.preventDefault();
-      setPendingNavigation(item.name);
-      setShowPasswordModal(true);
-    }
-  };
-
-  const handlePasswordSubmit = async (password: string) => {
-    const success = await login(password);
-    if (success && pendingNavigation) {
-      navigate(`/${pendingNavigation}`);
-      setPendingNavigation(null);
-    } else if (!success) {
-      throw new Error("Invalid password");
+      const success = await requestAuth();
+      if (success) {
+        navigate(`/${item.name}`);
+      }
     }
   };
 
   return (
-    <>
-      <nav className="fixed top-0 left-0 right-0 z-40 bg-gray-50 border-b border-gray-200 backdrop-blur-sm">
-        <div className="mx-auto px-12">
-          <div className="flex justify-between items-center h-16">
-            {/* Logo/Brand */}
-            <div className="flex items-center">
-              <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-gradient-to-br from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
-                  <Zap className="w-5 h-5 text-white" />
-                </div>
-                <h1 className="text-xl font-bold text-gray-900">
-                  Kernel Benchmark
-                </h1>
+    <nav className="fixed top-0 left-0 right-0 z-40 bg-gray-50 border-b border-gray-200 backdrop-blur-sm">
+      <div className="mx-auto px-12">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center">
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 bg-gradient-to-br from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
+                <Zap className="w-5 h-5 text-white" />
               </div>
-            </div>
-
-            {/* Navigation Items */}
-            <nav className="hidden md:flex items-center space-x-1">
-              {navItems.map((item) => {
-                const isLocked = item.requireAuth && !isAuthenticated;
-                const isActive = activePage === item.name;
-
-                return (
-                  <Link
-                    key={item.name}
-                    to={`/${item.name}`}
-                    onClick={(e) => handleNavClick(e, item)}
-                    className={twMerge(
-                      "flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200",
-                      isActive
-                        ? "bg-blue-100 text-blue-700 shadow-sm"
-                        : isLocked
-                          ? "text-gray-400 hover:text-gray-500"
-                          : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
-                    )}
-                  >
-                    {isLocked ? <Lock className="w-4 h-4" /> : item.icon}
-                    <span>{item.label}</span>
-                  </Link>
-                );
-              })}
-            </nav>
-
-            {/* Mobile menu button - placeholder for future mobile implementation */}
-            <div className="md:hidden">
-              <button className="p-2 rounded-lg text-gray-600 hover:text-gray-900 hover:bg-gray-100">
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
-                </svg>
-              </button>
+              <h1 className="text-xl font-bold text-gray-900">
+                Kernel Benchmark
+              </h1>
             </div>
           </div>
-        </div>
-      </nav>
 
-      <PasswordModal
-        isOpen={showPasswordModal}
-        onClose={() => {
-          setShowPasswordModal(false);
-          setPendingNavigation(null);
-        }}
-        onSubmit={handlePasswordSubmit}
-      />
-    </>
+          <nav className="hidden md:flex items-center space-x-1">
+            {navItems.map((item) => {
+              const isLocked = item.requireAuth && !isAuthenticated;
+              const isActive = activePage === item.name;
+
+              return (
+                <Link
+                  key={item.name}
+                  to={`/${item.name}`}
+                  onClick={(e) => handleNavClick(e, item)}
+                  className={twMerge(
+                    "flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200",
+                    isActive
+                      ? "bg-blue-100 text-blue-700 shadow-sm"
+                      : isLocked
+                        ? "text-gray-400 hover:text-gray-500"
+                        : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+                  )}
+                >
+                  {isLocked ? <Lock className="w-4 h-4" /> : item.icon}
+                  <span>{item.label}</span>
+                </Link>
+              );
+            })}
+
+            {isAuthenticated && (
+              <button
+                onClick={logout}
+                className="ml-2 px-3 py-2 rounded-lg text-sm font-medium text-gray-500 hover:text-red-600 hover:bg-red-50 transition-all duration-200"
+              >
+                Logout
+              </button>
+            )}
+          </nav>
+
+          <div className="md:hidden">
+            <button className="p-2 rounded-lg text-gray-600 hover:text-gray-900 hover:bg-gray-100">
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </nav>
   );
 };
 

--- a/dashboard/src/components/PageContainer.tsx
+++ b/dashboard/src/components/PageContainer.tsx
@@ -1,8 +1,7 @@
-// PageContainer.tsx
-import { type ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import type { PageName } from "./Navbar";
 import Navbar from "./Navbar";
-import { Loader2 } from "lucide-react";
+import { Loader2, Lock } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
 
 interface PageContainerProps {
@@ -19,14 +18,14 @@ export default function PageContainer({
   children,
   isLoading,
 }: PageContainerProps) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, requestAuth } = useAuth();
   const requireAuth = authPages.includes(activePage);
 
-  // useEffect(() => {
-  //   if (requireAuth && !isAuthenticated) {
-  //     navigate("/dashboard");
-  //   }
-  // }, [requireAuth, isAuthenticated, navigate]);
+  useEffect(() => {
+    if (requireAuth && !isAuthenticated) {
+      requestAuth();
+    }
+  }, [requireAuth, isAuthenticated, requestAuth]);
 
   return (
     <>
@@ -45,7 +44,22 @@ export default function PageContainer({
           )}
         </div>
       ) : (
-        "Waiting"
+        <div className="px-12 pt-24 pb-6">
+          <div className="flex items-center justify-center min-h-[60vh]">
+            <div className="flex flex-col items-center gap-4">
+              <Lock className="w-12 h-12 text-gray-400" />
+              <p className="text-gray-600 text-lg font-medium">
+                Authentication required to view this page
+              </p>
+              <button
+                onClick={() => requestAuth()}
+                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                Sign In
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </>
   );

--- a/dashboard/src/components/PageContainer.tsx
+++ b/dashboard/src/components/PageContainer.tsx
@@ -18,19 +18,20 @@ export default function PageContainer({
   children,
   isLoading,
 }: PageContainerProps) {
-  const { isAuthenticated, requestAuth } = useAuth();
+  const { isAuthenticated, isLoading: isAuthLoading, requestAuth } = useAuth();
   const requireAuth = authPages.includes(activePage);
+  const needsAuth = requireAuth && !isAuthenticated && !isAuthLoading;
 
   useEffect(() => {
-    if (requireAuth && !isAuthenticated) {
+    if (needsAuth) {
       requestAuth();
     }
-  }, [requireAuth, isAuthenticated, requestAuth]);
+  }, [needsAuth, requestAuth]);
 
   return (
     <>
       <Navbar activePage={activePage} />
-      {!requireAuth || isAuthenticated ? (
+      {!needsAuth ? (
         <div className="px-12 pt-24 pb-6">
           {isLoading ? (
             <div className="flex items-center justify-center min-h-[60vh]">

--- a/dashboard/src/components/Plots/BarPlot.tsx
+++ b/dashboard/src/components/Plots/BarPlot.tsx
@@ -19,7 +19,7 @@ Chart.register(
   LinearScale,
   Tooltip,
   Legend,
-  Title
+  Title,
 );
 
 interface BarComparisonPlotProps {
@@ -40,7 +40,7 @@ export function BarComparisonPlot({ kernels, metric }: BarComparisonPlotProps) {
     for (const kernel of kernels) {
       if (!backendGroups[kernel.backend]) backendGroups[kernel.backend] = [];
       backendGroups[kernel.backend].push(
-        metric === "tflops" ? kernel.tflops : kernel.meanMicroseconds
+        metric === "tflops" ? kernel.tflops : kernel.meanMicroseconds,
       );
     }
 
@@ -59,13 +59,14 @@ export function BarComparisonPlot({ kernels, metric }: BarComparisonPlotProps) {
             label: metric === "tflops" ? "Avg TFLOPs" : "Avg Mean Time (μs)",
             data,
             backgroundColor: labels.map((label) =>
-              getBackendColor(label).string()
+              getBackendColor(label).string(),
             ),
           },
         ],
       },
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           y: {
             title: {
@@ -84,5 +85,9 @@ export function BarComparisonPlot({ kernels, metric }: BarComparisonPlotProps) {
     });
   }, [kernels, metric]);
 
-  return <canvas ref={canvasRef} className="w-full h-[500px]" />;
+  return (
+    <div className="relative w-full h-[400px]">
+      <canvas ref={canvasRef} />
+    </div>
+  );
 }

--- a/dashboard/src/components/Plots/BellPlot.tsx
+++ b/dashboard/src/components/Plots/BellPlot.tsx
@@ -155,6 +155,7 @@ export function BellComparisonPlot({
       },
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           x: {
             type: "linear",
@@ -232,5 +233,9 @@ export function BellComparisonPlot({
     };
   }, [kernels, metric]);
 
-  return <canvas ref={canvasRef} className="w-full h-[500px]" />;
+  return (
+    <div className="relative w-full h-[500px]">
+      <canvas ref={canvasRef} />
+    </div>
+  );
 }

--- a/dashboard/src/components/Plots/RooflinePlot.tsx
+++ b/dashboard/src/components/Plots/RooflinePlot.tsx
@@ -25,7 +25,7 @@ Chart.register(
   Legend,
   LineController,
   LineElement,
-  zoomPlugin
+  zoomPlugin,
 );
 
 interface MachineRooflineStats {
@@ -114,7 +114,7 @@ export default function RooflinePlot({
 
     const xMin = Math.max(
       0.01,
-      Math.min(...kernels.map((k) => k.arithmeticIntensity))
+      Math.min(...kernels.map((k) => k.arithmeticIntensity)),
     );
     const xMax = Math.max(...kernels.map((k) => k.arithmeticIntensity)) * 2;
 
@@ -123,7 +123,7 @@ export default function RooflinePlot({
     const peakCompute = ROOFLINE_BY_MACHINE[machine].compute;
     const xRoofline = Array.from(
       { length: 100 },
-      (_, i) => xMin * Math.pow(xMax / xMin, i / 99)
+      (_, i) => xMin * Math.pow(xMax / xMin, i / 99),
     );
 
     const yMemory = xRoofline.map((x) => x * peakMemoryBandwidth);
@@ -162,6 +162,7 @@ export default function RooflinePlot({
       },
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           x: {
             type: "logarithmic",
@@ -224,5 +225,9 @@ export default function RooflinePlot({
     });
   }, [kernels, selectedKernel]);
 
-  return <canvas ref={canvasRef} className="w-full h-[500px]" />;
+  return (
+    <div className="relative w-full h-[600px]">
+      <canvas ref={canvasRef} />
+    </div>
+  );
 }

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -92,13 +92,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const requestAuth = useCallback((): Promise<boolean> => {
-    if (isAuthenticated) return Promise.resolve(true);
+    if (isAuthenticated || isLoading) return Promise.resolve(isAuthenticated);
 
     return new Promise((resolve) => {
       authCallbackRef.current = resolve;
       setShowAuthModal(true);
     });
-  }, [isAuthenticated]);
+  }, [isAuthenticated, isLoading]);
 
   const handleAuthSubmit = async (password: string) => {
     const success = await login(password);

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -1,134 +1,142 @@
-// contexts/AuthContext.tsx
-import React, { createContext, useState, useContext, useEffect } from "react";
+import React, {
+  createContext,
+  useState,
+  useContext,
+  useEffect,
+  useRef,
+  useCallback,
+} from "react";
+import PasswordModal from "../components/PasswordModal";
+
+const API_BASE_URL = import.meta.env.VITE_BACKEND_SERVER_URL;
+const TOKEN_KEY = "auth_token";
 
 interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (password: string) => Promise<boolean>;
-  logout: () => Promise<void>;
-  checkAuth: () => Promise<void>;
+  logout: () => void;
+  /** Prompt the user to authenticate. Resolves true on success, false on dismiss. */
+  requestAuth: () => Promise<boolean>;
+  getToken: () => string | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
-
-const API_BASE_URL = import.meta.env.VITE_BACKEND_SERVER_URL;
-
-class FetchError extends Error {
-  status: number;
-
-  constructor(message: string, status: number) {
-    super(message);
-    this.status = status;
-    this.name = "FetchError";
-  }
-}
-
-const fetchAPI = async <T = any,>(
-  endpoint: string,
-  options: RequestInit = {}
-): Promise<{ data: T; response: Response }> => {
-  const url = `${API_BASE_URL}${endpoint}`;
-
-  const defaultOptions: RequestInit = {
-    credentials: "include", // Include cookies in requests
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
-    ...options,
-  };
-
-  try {
-    const response = await fetch(url, defaultOptions);
-
-    let data: T;
-    const contentType = response.headers.get("content-type");
-
-    if (contentType && contentType.includes("application/json")) {
-      data = await response.json();
-    } else {
-      data = {} as T;
-    }
-
-    if (!response.ok) {
-      throw new FetchError(
-        (data as any)?.message || `HTTP error! status: ${response.status}`,
-        response.status
-      );
-    }
-
-    return { data, response };
-  } catch (error) {
-    if (error instanceof TypeError && error.message === "Failed to fetch") {
-      throw new Error("Network error. Please check your connection.");
-    }
-    throw error;
-  }
-};
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [showAuthModal, setShowAuthModal] = useState(false);
 
-  const checkAuth = async () => {
+  const authCallbackRef = useRef<((success: boolean) => void) | null>(null);
+
+  const getToken = useCallback(() => localStorage.getItem(TOKEN_KEY), []);
+
+  const checkAuth = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      setIsAuthenticated(false);
+      setIsLoading(false);
+      return;
+    }
+
     try {
-      const { data } = await fetchAPI<{ authenticated: boolean }>(
-        "/auth/verify"
-      );
-      setIsAuthenticated(data.authenticated);
-    } catch (error) {
+      const response = await fetch(`${API_BASE_URL}/auth/verify`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await response.json();
+      if (data.authenticated) {
+        setIsAuthenticated(true);
+      } else {
+        localStorage.removeItem(TOKEN_KEY);
+        setIsAuthenticated(false);
+      }
+    } catch {
       setIsAuthenticated(false);
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [getToken]);
 
   useEffect(() => {
     checkAuth();
-  }, []);
+  }, [checkAuth]);
 
-  const login = async (password: string): Promise<boolean> => {
+  const login = useCallback(async (password: string): Promise<boolean> => {
     try {
-      await fetchAPI<{ message: string }>("/auth/login", {
+      const response = await fetch(`${API_BASE_URL}/auth/login`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ password }),
       });
 
-      setIsAuthenticated(true);
-      return true;
-    } catch (error) {
-      setIsAuthenticated(false);
+      if (!response.ok) return false;
 
-      if (error instanceof FetchError && error.status === 401) {
-        // Invalid password
-        return false;
+      const data = await response.json();
+      if (data.token) {
+        localStorage.setItem(TOKEN_KEY, data.token);
+        setIsAuthenticated(true);
+        return true;
       }
+      return false;
+    } catch {
+      return false;
+    }
+  }, []);
 
-      // Re-throw other errors for the component to handle
-      throw error;
+  const logout = useCallback(() => {
+    localStorage.removeItem(TOKEN_KEY);
+    setIsAuthenticated(false);
+  }, []);
+
+  const requestAuth = useCallback((): Promise<boolean> => {
+    if (isAuthenticated) return Promise.resolve(true);
+
+    return new Promise((resolve) => {
+      authCallbackRef.current = resolve;
+      setShowAuthModal(true);
+    });
+  }, [isAuthenticated]);
+
+  const handleAuthSubmit = async (password: string) => {
+    const success = await login(password);
+    if (success) {
+      setShowAuthModal(false);
+      authCallbackRef.current?.(true);
+      authCallbackRef.current = null;
+    } else {
+      throw new Error("Invalid password");
     }
   };
 
-  const logout = async () => {
-    try {
-      await fetchAPI("/auth/logout", {
-        method: "POST",
-      });
-    } catch (error) {
-      console.error("Logout failed:", error);
-    } finally {
-      // Always set authenticated to false
+  const handleAuthClose = () => {
+    setShowAuthModal(false);
+    authCallbackRef.current?.(false);
+    authCallbackRef.current = null;
+  };
+
+  useEffect(() => {
+    const handler = () => {
+      localStorage.removeItem(TOKEN_KEY);
       setIsAuthenticated(false);
-    }
-  };
+      setShowAuthModal(true);
+    };
+    window.addEventListener("auth-required", handler);
+    return () => window.removeEventListener("auth-required", handler);
+  }, []);
 
   return (
     <AuthContext.Provider
-      value={{ isAuthenticated, isLoading, login, logout, checkAuth }}
+      value={{ isAuthenticated, isLoading, login, logout, requestAuth, getToken }}
     >
       {children}
+      <PasswordModal
+        isOpen={showAuthModal}
+        onClose={handleAuthClose}
+        onSubmit={handleAuthSubmit}
+      />
     </AuthContext.Provider>
   );
 };

--- a/dashboard/src/pages/Tracking.tsx
+++ b/dashboard/src/pages/Tracking.tsx
@@ -30,6 +30,7 @@ import {
   ExternalLink,
   GitBranch,
 } from "lucide-react";
+import DayTimeline from "../components/DayTimeline";
 
 interface Tracker {
   id: string;
@@ -239,6 +240,20 @@ export default function Tracking() {
               Add Tracker
             </button>
           </div>
+
+          {/* Day Timeline */}
+          {!isLoading && trackers.length > 0 && (
+            <DayTimeline
+              trackers={trackers.map((t) => ({
+                id: t.id,
+                name: t.name,
+                machine: t.machine,
+                isActive: t.isActive,
+                schedule: t.schedule,
+                tags: t.tags,
+              }))}
+            />
+          )}
 
           {/* Trackers List */}
           {!isLoading && trackers.length === 0 ? (

--- a/dashboard/src/utils/github.ts
+++ b/dashboard/src/utils/github.ts
@@ -11,68 +11,79 @@ import type {
   RunWithTrigger,
 } from "../types";
 
-export async function fetchModifications() {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/pull_requests`
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
+const API_URL = import.meta.env.VITE_BACKEND_SERVER_URL;
+const TOKEN_KEY = "auth_token";
 
-    const data = await response.json();
-    const modifications: RepoPullRequest[] = [];
+/**
+ * Centralized fetch wrapper that attaches the auth token and emits
+ * an `auth-required` event when the server responds with 401.
+ */
+async function apiFetch(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const token = localStorage.getItem(TOKEN_KEY);
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string>),
+  };
 
-    for (let obj of data) {
-      obj["timestamp"] = new Date(obj["timestamp"]);
-      modifications.push(obj as RepoPullRequest);
-    }
-
-    modifications.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-    console.log("modifications", modifications);
-
-    return modifications;
-  } catch (error) {
-    throw new Error(`Failed to fetch pull requests: ${error}`);
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
   }
+
+  const response = await fetch(`${API_URL}${endpoint}`, {
+    ...options,
+    headers,
+  });
+
+  if (response.status === 401) {
+    window.dispatchEvent(new CustomEvent("auth-required"));
+    throw new Error("Authentication required");
+  }
+
+  return response;
+}
+
+export async function fetchModifications() {
+  const response = await apiFetch("/pull_requests");
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const modifications: RepoPullRequest[] = [];
+
+  for (let obj of data) {
+    obj["timestamp"] = new Date(obj["timestamp"]);
+    modifications.push(obj as RepoPullRequest);
+  }
+
+  modifications.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  return modifications;
 }
 
 export async function fetchRuns() {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/runs`
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    const jobs: BenchmarkRun[] = await response.json();
-    return jobs;
-  } catch (error) {
-    throw new Error(`Failed to fetch runs: ${error}`);
+  const response = await apiFetch("/runs");
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+
+  const jobs: BenchmarkRun[] = await response.json();
+  return jobs;
 }
 
 export async function fetchPerformanceRuns() {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/performances`
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    const perfs: BenchmarkRun[] = await response.json();
-    return perfs;
-  } catch (error) {
-    throw new Error(`Failed to fetch runs: ${error}`);
+  const response = await apiFetch("/performances");
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+
+  const perfs: BenchmarkRun[] = await response.json();
+  return perfs;
 }
 
 export async function fetchKernels() {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernels`
-  );
+  const response = await apiFetch("/kernels");
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
@@ -82,9 +93,7 @@ export async function fetchKernels() {
 }
 
 export async function fetchTuningResults() {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/tune/results`
-  );
+  const response = await apiFetch("/tune/results");
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
@@ -109,15 +118,11 @@ export async function fetchTuningResults() {
     );
   }
 
-  console.log("Tuning Results", tuningResults);
-
   return tuningResults;
 }
 
 export async function fetchInProgressTuningRuns() {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/tune/runs`
-  );
+  const response = await apiFetch("/tune/runs");
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
@@ -128,9 +133,7 @@ export async function fetchInProgressTuningRuns() {
 }
 
 export async function fetchChangeStats() {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/change_stats`
-  );
+  const response = await apiFetch("/change_stats");
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
@@ -145,12 +148,7 @@ export async function fetchChangeStats() {
 }
 
 export async function rebase() {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/rebase`,
-    {
-      method: "POST",
-    }
-  );
+  const response = await apiFetch("/rebase", { method: "POST" });
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
@@ -165,21 +163,12 @@ export async function triggerBenchWorkflow(
   pullRequest: RepoPullRequest,
   config: BenchmarkRuntimeConfig
 ) {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/workflow/pr/trigger`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        pr: pullRequest,
-        config,
-      }),
-    }
-  );
+  const response = await apiFetch("/workflow/pr/trigger", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pr: pullRequest, config }),
+  });
   if (!response.ok) {
-    console.log(response.statusText);
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
 }
@@ -190,53 +179,34 @@ export async function triggerManualBenchWorkflow(config: {
   backends: string[];
   kernelSelection: KernelSelection;
 }) {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/workflow/manual/trigger`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        config,
-      }),
-    }
-  );
+  const response = await apiFetch("/workflow/manual/trigger", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ config }),
+  });
   if (!response.ok) {
-    console.log(response.statusText);
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
 }
 
 export async function cancelWorkflow(runId: string) {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/workflow/cancel`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ runId }),
-    }
-  );
+  const response = await apiFetch("/workflow/cancel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ runId }),
+  });
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
 }
 
 export async function triggerTuningWorkflow(kernelIds: string[]) {
-  const response = await fetch(
-    `${import.meta.env.VITE_BACKEND_SERVER_URL}/tune`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ kernel_ids: kernelIds }),
-    }
-  );
+  const response = await apiFetch("/tune", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kernel_ids: kernelIds }),
+  });
   if (!response.ok) {
-    console.log(response.statusText);
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
 }
@@ -244,97 +214,62 @@ export async function triggerTuningWorkflow(kernelIds: string[]) {
 // Kernel Type Management Functions
 
 export async function fetchKernelTypes(): Promise<KernelTypeDefinition[]> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernel_types`
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    const kernelTypes: KernelTypeDefinition[] = await response.json();
-    return kernelTypes;
-  } catch (error) {
-    throw new Error(`Failed to fetch kernel types: ${error}`);
+  const response = await apiFetch("/kernel_types");
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+  return response.json();
 }
 
 export async function addKernelType(
   kernelType: KernelTypeDefinition
 ): Promise<KernelTypeDefinition> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernel_types`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(kernelType),
-      }
+  const response = await apiFetch("/kernel_types", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(kernelType),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
     );
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-
-    const createdKernelType: KernelTypeDefinition = await response.json();
-    return createdKernelType;
-  } catch (error) {
-    throw new Error(`Failed to add kernel type: ${error}`);
   }
+
+  return response.json();
 }
 
 export async function updateKernelType(
   kernelTypeId: string,
   updates: Partial<Omit<KernelTypeDefinition, "_id">>
 ): Promise<KernelTypeDefinition> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernel_types/${kernelTypeId}`,
-      {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updates),
-      }
+  const response = await apiFetch(`/kernel_types/${kernelTypeId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(updates),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
     );
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-
-    const updatedKernelType: KernelTypeDefinition = await response.json();
-    return updatedKernelType;
-  } catch (error) {
-    throw new Error(`Failed to update kernel type: ${error}`);
   }
+
+  return response.json();
 }
 
 export async function deleteKernelType(kernelTypeId: string): Promise<void> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernel_types/${kernelTypeId}`,
-      {
-        method: "DELETE",
-      }
-    );
+  const response = await apiFetch(`/kernel_types/${kernelTypeId}`, {
+    method: "DELETE",
+  });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-  } catch (error) {
-    throw new Error(`Failed to delete kernel type: ${error}`);
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
+    );
   }
 }
 
@@ -343,82 +278,53 @@ export async function deleteKernelType(kernelTypeId: string): Promise<void> {
 export async function addKernels(
   kernelConfigs: Omit<KernelConfig, "_id">[]
 ): Promise<KernelConfig[]> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernels`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(kernelConfigs),
-      }
+  const response = await apiFetch("/kernels", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(kernelConfigs),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
     );
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-
-    const createdKernels: KernelConfig[] = await response.json();
-    return createdKernels;
-  } catch (error) {
-    throw new Error(`Failed to add kernels: ${error}`);
   }
+
+  return response.json();
 }
 
 export async function updateKernels(
   kernelUpdates: Partial<KernelConfig>[]
 ): Promise<KernelConfig[]> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernels/batch`,
-      {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(kernelUpdates),
-      }
+  const response = await apiFetch("/kernels/batch", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(kernelUpdates),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
     );
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-
-    const updatedKernels: KernelConfig[] = await response.json();
-    return updatedKernels;
-  } catch (error) {
-    throw new Error(`Failed to update kernels: ${error}`);
   }
+
+  return response.json();
 }
 
 export async function deleteKernels(kernelIds: string[]): Promise<void> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/kernels`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ ids: kernelIds }),
-      }
-    );
+  const response = await apiFetch("/kernels", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ids: kernelIds }),
+  });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-  } catch (error) {
-    throw new Error(`Failed to delete kernels: ${error}`);
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
+    );
   }
 }
 
@@ -445,85 +351,71 @@ export interface FetchRunsResponse {
 export async function fetchAllRuns(
   params: FetchRunsParams = {}
 ): Promise<FetchRunsResponse> {
-  try {
-    const queryParams = new URLSearchParams();
-    if (params.page) queryParams.append("page", params.page.toString());
-    if (params.page_size)
-      queryParams.append("page_size", params.page_size.toString());
-    if (params.type) queryParams.append("type", params.type);
-    if (params.has_artifact !== undefined)
-      queryParams.append("has_artifact", params.has_artifact.toString());
-    if (params.completed_only !== undefined)
-      queryParams.append("completed_only", params.completed_only.toString());
+  const queryParams = new URLSearchParams();
+  if (params.page) queryParams.append("page", params.page.toString());
+  if (params.page_size)
+    queryParams.append("page_size", params.page_size.toString());
+  if (params.type) queryParams.append("type", params.type);
+  if (params.has_artifact !== undefined)
+    queryParams.append("has_artifact", params.has_artifact.toString());
+  if (params.completed_only !== undefined)
+    queryParams.append("completed_only", params.completed_only.toString());
 
-    const url = `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/runs${
-      queryParams.toString() ? `?${queryParams.toString()}` : ""
-    }`;
-
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    const data: FetchRunsResponse = await response.json();
-
-    // Convert timestamp strings to Date objects for both run and trigger
-    data.runs = data.runs.map((item) => ({
-      run: item.run
-        ? {
-            ...item.run,
-            timestamp: new Date(item.run.timestamp),
-          }
-        : null,
-      trigger: item.trigger
-        ? {
-            ...item.trigger,
-            timestamp: new Date(item.trigger.timestamp),
-            dispatchedAt: item.trigger.dispatchedAt
-              ? new Date(item.trigger.dispatchedAt)
-              : undefined,
-            linkedAt: item.trigger.linkedAt
-              ? new Date(item.trigger.linkedAt)
-              : undefined,
-          }
-        : null,
-    }));
-
-    return data;
-  } catch (error) {
-    throw new Error(`Failed to fetch runs: ${error}`);
+  const qs = queryParams.toString();
+  const response = await apiFetch(`/api/runs${qs ? `?${qs}` : ""}`);
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+
+  const data: FetchRunsResponse = await response.json();
+
+  data.runs = data.runs.map((item) => ({
+    run: item.run
+      ? {
+          ...item.run,
+          timestamp: new Date(item.run.timestamp),
+        }
+      : null,
+    trigger: item.trigger
+      ? {
+          ...item.trigger,
+          timestamp: new Date(item.trigger.timestamp),
+          dispatchedAt: item.trigger.dispatchedAt
+            ? new Date(item.trigger.dispatchedAt)
+            : undefined,
+          linkedAt: item.trigger.linkedAt
+            ? new Date(item.trigger.linkedAt)
+            : undefined,
+        }
+      : null,
+  }));
+
+  return data;
 }
 
 export async function deleteRun(runId: string): Promise<void> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/runs/${runId}`,
-      {
-        method: "DELETE",
-      }
-    );
+  const response = await apiFetch(`/api/runs/${runId}`, {
+    method: "DELETE",
+  });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-  } catch (error) {
-    throw new Error(`Failed to delete run: ${error}`);
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
+    );
   }
 }
 
 // Tracker types
+
 export interface ScheduleData {
   isInterval: boolean;
-  startDate: string; // MM-DD-YYYY
-  timeOfDay: string; // HH:MM in UTC
-  daysOfWeek?: string[]; // For weekly schedules
-  intervalValue?: number; // For interval schedules
-  intervalUnit?: "weeks" | "months"; // For interval schedules
-  endDate?: string; // MM-DD-YYYY
+  startDate: string;
+  timeOfDay: string;
+  daysOfWeek?: string[];
+  intervalValue?: number;
+  intervalUnit?: "weeks" | "months";
+  endDate?: string;
 }
 
 export interface TrackerData {
@@ -541,152 +433,97 @@ export interface TrackerData {
 }
 
 export async function fetchTrackers(): Promise<TrackerData[]> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers`
-    );
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    const data: TrackerData[] = await response.json();
-    return data;
-  } catch (error) {
-    throw new Error(`Failed to fetch trackers: ${error}`);
+  const response = await apiFetch("/api/trackers");
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+  return response.json();
 }
 
-export async function createTracker(tracker: TrackerData): Promise<TrackerData> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(tracker),
-      }
+export async function createTracker(
+  tracker: TrackerData
+): Promise<TrackerData> {
+  const response = await apiFetch("/api/trackers", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(tracker),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
     );
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-
-    const data: TrackerData = await response.json();
-    return data;
-  } catch (error) {
-    throw new Error(`Failed to create tracker: ${error}`);
   }
+
+  return response.json();
 }
 
 export async function updateTracker(
   trackerId: string,
   tracker: Partial<TrackerData>
 ): Promise<TrackerData> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}`,
-      {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(tracker),
-      }
+  const response = await apiFetch(`/api/trackers/${trackerId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(tracker),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
     );
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-
-    const data: TrackerData = await response.json();
-    return data;
-  } catch (error) {
-    throw new Error(`Failed to update tracker: ${error}`);
   }
+
+  return response.json();
 }
 
 export async function deleteTracker(trackerId: string): Promise<void> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}`,
-      {
-        method: "DELETE",
-      }
-    );
+  const response = await apiFetch(`/api/trackers/${trackerId}`, {
+    method: "DELETE",
+  });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-  } catch (error) {
-    throw new Error(`Failed to delete tracker: ${error}`);
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
+    );
   }
 }
 
 export async function triggerTrackerRun(trackerId: string): Promise<void> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}/trigger`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }
-    );
+  const response = await apiFetch(`/api/trackers/${trackerId}/trigger`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! Status: ${response.status}`
-      );
-    }
-  } catch (error) {
-    throw new Error(`Failed to trigger tracker run: ${error}`);
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! Status: ${response.status}`
+    );
   }
 }
 
-export async function fetchTrackerByDashboardName(dashboardName: string): Promise<TrackerData> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/dashboard/${dashboardName}`
-    );
-    
-    if (!response.ok) {
-      throw new Error("Tracker not found");
-    }
-    
-    return await response.json();
-  } catch (error) {
-    throw new Error(`Failed to fetch tracker by dashboard name: ${error}`);
+export async function fetchTrackerByDashboardName(
+  dashboardName: string
+): Promise<TrackerData> {
+  const response = await apiFetch(
+    `/api/trackers/dashboard/${dashboardName}`
+  );
+  if (!response.ok) {
+    throw new Error("Tracker not found");
   }
+  return response.json();
 }
 
 export async function fetchTrackerRuns(trackerId: string): Promise<any[]> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}/runs`
-    );
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    
-    return await response.json();
-  } catch (error) {
-    throw new Error(`Failed to fetch tracker runs: ${error}`);
+  const response = await apiFetch(`/api/trackers/${trackerId}/runs`);
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+  return response.json();
 }
 
 export async function fetchTrackerPerformanceTimeline(
@@ -694,40 +531,24 @@ export async function fetchTrackerPerformanceTimeline(
   startDate?: string,
   endDate?: string
 ): Promise<any[]> {
-  try {
-    const params = new URLSearchParams();
-    if (startDate) params.append("start_date", startDate);
-    if (endDate) params.append("end_date", endDate);
-    
-    const url = `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}/performance${
-      params.toString() ? `?${params.toString()}` : ""
-    }`;
-    
-    const response = await fetch(url);
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    
-    return await response.json();
-  } catch (error) {
-    throw new Error(`Failed to fetch tracker performance timeline: ${error}`);
+  const params = new URLSearchParams();
+  if (startDate) params.append("start_date", startDate);
+  if (endDate) params.append("end_date", endDate);
+
+  const qs = params.toString();
+  const response = await apiFetch(
+    `/api/trackers/${trackerId}/performance${qs ? `?${qs}` : ""}`
+  );
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+  return response.json();
 }
 
 export async function fetchBranches(): Promise<string[]> {
-  try {
-    const response = await fetch(
-      `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/branches`
-    );
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    
-    const branches: string[] = await response.json();
-    return branches;
-  } catch (error) {
-    throw new Error(`Failed to fetch branches: ${error}`);
+  const response = await apiFetch("/api/branches");
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+  return response.json();
 }


### PR DESCRIPTION
## Dashboard Repair: Auth Refactor, Event Loop Robustness, and Plot Fixes

### Summary

- **Refactored authentication from cookie-based to Bearer token auth** -- JWT tokens are now stored in `localStorage` (24h expiry, up from 30min), the `PasswordModal` is centralized in `AuthContext`, and all mutation endpoints now enforce `@token_required`. Protected pages auto-prompt for sign-in with a proper locked-page UI.
- **Fixed event loop run tracking when webhooks are inactive** -- The reconciliation path in `RunManager` now creates a `WorkflowRunState` record when linking orphaned triggers, so runs discovered via polling (not webhooks) can still be tracked and have their artifacts downloaded.
- **Added `--handlers` and `--once` CLI flags to the event loop** for safe local development, allowing selective execution of individual handlers (e.g., `--handlers run_manager --once`) without risking duplicate dispatches against production.
- **Added a day timeline component on the tracker page** (`DayTimeline.tsx`) for visualizing scheduled and completed tracker runs.
- **Fixed Chart.js plot scaling issues** across Roofline, Bar, and Bell plots by setting `maintainAspectRatio: false` and wrapping canvases in properly sized container divs, preventing charts from overflowing or rendering at incorrect sizes.

### Test Plan

- [x] Verify login flow: clicking a locked nav item prompts the password modal, successful auth navigates to the page, token persists across page refreshes
- [x] Verify logout button appears when authenticated and clears the session
- [x] Confirm protected API endpoints (kernel CRUD, workflow triggers, tracker management) reject unauthenticated requests with 401
- [x] Test event loop with `--handlers run_manager --once` to confirm selective handler execution works
- [x] Simulate missed webhooks and verify `RunManager` reconciliation creates the `WorkflowRunState` and downloads artifacts
- [x] Check that Roofline, Bar, and Bell plots render at correct sizes without overflow on both wide and narrow viewports
- [x] Verify the day timeline renders on the tracker page with scheduled run data