### PR TITLE
Backend specs improvements: multi-select UI, backendParam support, and workflow enhancements

### DIFF
--- a/.github/workflows/short_bench.yml
+++ b/.github/workflows/short_bench.yml
@@ -74,6 +74,59 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+
+      - name: Parse Backend Specs
+        id: backend_specs
+        if: ${{ inputs.backend_specs_url }}
+        run: |
+          SPECS=$(curl -sL "${{ inputs.backend_specs_url }}")
+          # Extract wave repo/branch from specs (wave or wave_* backends, e.g. wave_4wave_rocroller)
+          WAVE_REPO=$(echo "$SPECS" | python3 -c "
+          import json, sys
+          specs = json.load(sys.stdin)
+          for s in specs:
+              b = str(s.get('backend', '')).lower()
+              if (b == 'wave' or b.startswith('wave_')) and s.get('remoteRepository'):
+                  print(s['remoteRepository'])
+                  break
+          " 2>/dev/null || echo "")
+          WAVE_BRANCH=$(echo "$SPECS" | python3 -c "
+          import json, sys
+          specs = json.load(sys.stdin)
+          for s in specs:
+              b = str(s.get('backend', '')).lower()
+              if (b == 'wave' or b.startswith('wave_')) and s.get('branch'):
+                  print(s['branch'])
+                  break
+          " 2>/dev/null || echo "")
+          # Extract rocm-libraries repo/branch: prefer any spec with buildMeta set,
+          # fall back to rocroller variants for backward compatibility
+          ROCM_LIBRARIES_REPO=$(echo "$SPECS" | python3 -c "
+          import json, sys
+          specs = json.load(sys.stdin)
+          for s in specs:
+              meta = s.get('buildMeta', {})
+              if meta.get('rocmLibrariesRepo'):
+                  print(meta['rocmLibrariesRepo'])
+                  break
+          " 2>/dev/null || echo "")
+          ROCM_LIBRARIES_BRANCH=$(echo "$SPECS" | python3 -c "
+          import json, sys
+          specs = json.load(sys.stdin)
+          for s in specs:
+              meta = s.get('buildMeta', {})
+              if meta.get('rocmLibrariesBranch'):
+                  print(meta['rocmLibrariesBranch'])
+                  break
+          " 2>/dev/null || echo "")
+          echo "wave_repo=$WAVE_REPO" >> $GITHUB_OUTPUT
+          echo "wave_branch=$WAVE_BRANCH" >> $GITHUB_OUTPUT
+          echo "rocm_libraries_repo=$ROCM_LIBRARIES_REPO" >> $GITHUB_OUTPUT
+          echo "rocm_libraries_branch=$ROCM_LIBRARIES_BRANCH" >> $GITHUB_OUTPUT
+          echo "Parsed wave repo: $WAVE_REPO, branch: $WAVE_BRANCH"
+          echo "Parsed rocm-libraries repo: $ROCM_LIBRARIES_REPO, branch: $ROCM_LIBRARIES_BRANCH"
+
+
       - name: Build Docker Image
         run: |
           cd benchmark

--- a/.github/workflows/short_bench.yml
+++ b/.github/workflows/short_bench.yml
@@ -149,6 +149,7 @@ jobs:
             --kernel-types ${{ inputs.selected_kernel }} \
             --problems-url ${{ inputs.problems_url }} \
             ${{ inputs.tuned_config_url && format('--tuned-configs-url {0}', inputs.tuned_config_url) || '' }} \
+            ${{ inputs.backend_specs_url && format('--backend-specs-url {0}', inputs.backend_specs_url) || '' }} \
             -o $(pwd)/benchmark_results
 
       - name: Upload benchmark results

--- a/backend/perf/statistics.py
+++ b/backend/perf/statistics.py
@@ -13,6 +13,35 @@ from typing import List, Dict, Any
 logger = logging.getLogger(__name__)
 
 
+def _get_macrotile_key(kernel: Dict) -> str | None:
+    """Extract macrotile string (e.g. '256x192x256') from kernel's tuningConfig."""
+    tc = kernel.get("tuningConfig")
+    if not tc:
+        return None
+    bm = tc.get("BLOCK_M")
+    bn = tc.get("BLOCK_N")
+    bk = tc.get("BLOCK_K")
+    if bm is None or bn is None or bk is None:
+        return None
+    return f"{bm}x{bn}x{bk}"
+
+
+def _compute_stats_for_list(kernel_list: List[Dict]) -> Dict[str, Any]:
+    tflops_values = [k["tflops"] for k in kernel_list]
+    runtime_values = [k["meanMicroseconds"] for k in kernel_list]
+    return {
+        "geoMean": {
+            "tflops": calculate_geometric_mean(tflops_values),
+            "runtimeUs": calculate_geometric_mean(runtime_values),
+        },
+        "average": {
+            "tflops": calculate_arithmetic_mean(tflops_values),
+            "runtimeUs": calculate_arithmetic_mean(runtime_values),
+        },
+        "numKernels": len(kernel_list),
+    }
+
+
 def compute_performance_statistics(kernels: List[Dict]) -> Dict[str, Any]:
     """
     Compute performance statistics for a list of kernels.
@@ -21,6 +50,7 @@ def compute_performance_statistics(kernels: List[Dict]) -> Dict[str, Any]:
     - Geometric mean of tflops and runtime
     - Arithmetic average of tflops and runtime
     - Count of valid kernels
+    - Per-macrotile breakdown (byMacrotile key)
 
     Args:
         kernels: List of kernel dictionaries with performance data
@@ -33,13 +63,19 @@ def compute_performance_statistics(kernels: List[Dict]) -> Dict[str, Any]:
                     "backend": {
                         "geoMean": {"tflops": float, "runtimeUs": float},
                         "average": {"tflops": float, "runtimeUs": float},
-                        "numKernels": int
+                        "numKernels": int,
+                        "byMacrotile": {
+                            "256x192x256": {
+                                "geoMean": {...}, "average": {...}, "numKernels": int
+                            },
+                            ...
+                        }
                     }
                 }
             }
         }
     """
-    # Group kernels by machine → kernel_type → backend
+    # Group kernels by machine → kernel_type → backend → macrotile
     grouped = {}
 
     for kernel in kernels:
@@ -59,9 +95,23 @@ def compute_performance_statistics(kernels: List[Dict]) -> Dict[str, Any]:
         if kernel_type not in grouped[machine]:
             grouped[machine][kernel_type] = {}
         if backend not in grouped[machine][kernel_type]:
-            grouped[machine][kernel_type][backend] = []
+            grouped[machine][kernel_type][backend] = {"_all": [], "byMacrotile": {}, "byKernelSource": {}}
 
-        grouped[machine][kernel_type][backend].append(kernel)
+        grouped[machine][kernel_type][backend]["_all"].append(kernel)
+
+        macrotile = _get_macrotile_key(kernel)
+        if macrotile:
+            by_mt = grouped[machine][kernel_type][backend]["byMacrotile"]
+            if macrotile not in by_mt:
+                by_mt[macrotile] = []
+            by_mt[macrotile].append(kernel)
+
+        kernel_source = kernel.get("kernelSource")
+        if kernel_source:
+            by_ks = grouped[machine][kernel_type][backend]["byKernelSource"]
+            if kernel_source not in by_ks:
+                by_ks[kernel_source] = []
+            by_ks[kernel_source].append(kernel)
 
     # Calculate statistics for each group
     stats = {}
@@ -72,21 +122,18 @@ def compute_performance_statistics(kernels: List[Dict]) -> Dict[str, Any]:
         for kernel_type, backends in kernel_types.items():
             stats[machine][kernel_type] = {}
 
-            for backend, kernel_list in backends.items():
-                tflops_values = [k["tflops"] for k in kernel_list]
-                runtime_values = [k["meanMicroseconds"] for k in kernel_list]
-
-                stats[machine][kernel_type][backend] = {
-                    "geoMean": {
-                        "tflops": calculate_geometric_mean(tflops_values),
-                        "runtimeUs": calculate_geometric_mean(runtime_values),
-                    },
-                    "average": {
-                        "tflops": calculate_arithmetic_mean(tflops_values),
-                        "runtimeUs": calculate_arithmetic_mean(runtime_values),
-                    },
-                    "numKernels": len(kernel_list),
+            for backend, data in backends.items():
+                kernel_list = data["_all"]
+                backend_stats = _compute_stats_for_list(kernel_list)
+                backend_stats["byMacrotile"] = {
+                    mt: _compute_stats_for_list(mt_kernels)
+                    for mt, mt_kernels in data["byMacrotile"].items()
                 }
+                backend_stats["byKernelSource"] = {
+                    ks: _compute_stats_for_list(ks_kernels)
+                    for ks, ks_kernels in data["byKernelSource"].items()
+                }
+                stats[machine][kernel_type][backend] = backend_stats
 
     return stats
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -81,9 +81,13 @@ def _generate_default_backend_specs(backends: list[str]) -> list[dict]:
             "name": "Wave 4-wave (baseline)",
             "backend": "wave",
             "backendParam": "wave_4wave_baseline",
-            "remoteRepository": "panditsa/wave",
-            "branch": "4waveasm-256x192x256",
+            "remoteRepository": "iree-org/wave",
+            "branch": "main",
             "isDefault": False,
+            "buildMeta": {
+                "rocmLibrariesRepo": "ROCm/rocm-libraries",
+                "rocmLibrariesBranch": "develop",
+            },
         },
         "wave_8wave": {
             "id": "wave-8wave",

--- a/backend/server.py
+++ b/backend/server.py
@@ -1391,10 +1391,12 @@ def get_tracker_performance_timeline(tracker_id):
     try:
         start_date = request.args.get("start_date")
         end_date = request.args.get("end_date")
-        
+        macrotile = request.args.get("macrotile")  # e.g. "256x192x256"
+        kernel_source = request.args.get("kernel_source")  # e.g. "wave", "aiter", "rocroller"
+
         # Query BenchmarkRunStats for this tracker
         stats = BenchmarkRunStatsDb.query(f"trackerId eq '{tracker_id}'")
-        
+
         # Filter by date range if provided
         if start_date:
             start_dt = datetime.fromisoformat(start_date)
@@ -1402,34 +1404,84 @@ def get_tracker_performance_timeline(tracker_id):
         if end_date:
             end_dt = datetime.fromisoformat(end_date)
             stats = [s for s in stats if s.timestamp <= end_dt]
-        
+
         # Sort by timestamp
         stats.sort(key=lambda s: s.timestamp)
-        
+
         # Transform data for frontend consumption
         timeline = []
         for stat in stats:
-            # Extract backend performance from stat.performance dict
-            # Format: performance[machine][kernel_type][backend] = {avg_tflops, geomean_tflops, ...}
             backends_data = {}
+            available_macrotiles = set()
+            available_kernel_sources = set()
             for machine_data in stat.performance.values():
                 for kernel_type_data in machine_data.values():
                     for backend, metrics in kernel_type_data.items():
+                        for mt in metrics.get("byMacrotile", {}).keys():
+                            available_macrotiles.add(mt)
+                        for ks in metrics.get("byKernelSource", {}).keys():
+                            available_kernel_sources.add(ks)
+
                         if backend not in backends_data:
-                            backends_data[backend] = metrics
-            
+                            if macrotile and macrotile in metrics.get("byMacrotile", {}):
+                                backends_data[backend] = metrics["byMacrotile"][macrotile]
+                            elif kernel_source and kernel_source in metrics.get("byKernelSource", {}):
+                                backends_data[backend] = metrics["byKernelSource"][kernel_source]
+                            else:
+                                backends_data[backend] = {
+                                    k: v for k, v in metrics.items()
+                                    if k not in ("byMacrotile", "byKernelSource")
+                                }
+
             timeline.append({
                 "timestamp": stat.timestamp.isoformat(),
                 "runId": stat.runId,
                 "backends": backends_data,
-                "backendSpecs": stat.backendSpecs if stat.backendSpecs else None
+                "backendSpecs": stat.backendSpecs if stat.backendSpecs else None,
+                "availableMacrotiles": sorted(available_macrotiles),
+                "availableKernelSources": sorted(available_kernel_sources),
             })
-        
+
         return jsonify(timeline)
     except Exception as e:
         logger.error(f"Error getting tracker performance timeline for {tracker_id}: {e}")
         logger.error(traceback.format_exc())
         return jsonify({"error": f"Failed to get tracker performance timeline: {str(e)}"}), 500
+
+
+@app.route("/api/runs/<run_id>/recompute-stats", methods=["POST"])
+def recompute_run_stats(run_id):
+    """Recompute BenchmarkRunStats for a run using the current statistics code."""
+    try:
+        run = WorkflowRunDb.find_by_id(run_id)
+        if not run:
+            return jsonify({"error": f"Run {run_id} not found"}), 404
+
+        kernels = get_artifact_parser(RunType.BENCHMARK).load_data(run.blobName)
+        if not kernels:
+            return jsonify({"error": "Failed to load artifact data"}), 500
+
+        from backend.perf.statistics import compute_performance_statistics
+        performance = compute_performance_statistics(kernels)
+
+        existing = BenchmarkRunStatsDb.query(f"runId eq '{run_id}'")
+        if existing:
+            BenchmarkRunStatsDb.update_by_id(existing[0]._id, {"performance": performance})
+            return jsonify({"message": f"Recomputed stats for run {run_id}", "statsId": existing[0]._id})
+        else:
+            stats = BenchmarkRunStats(
+                _id=str(uuid4()),
+                runId=run_id,
+                timestamp=datetime.now(timezone.utc),
+                machine=run.machine or "unknown",
+                performance=performance,
+            )
+            BenchmarkRunStatsDb.upsert(stats)
+            return jsonify({"message": f"Created stats for run {run_id}", "statsId": stats._id})
+    except Exception as e:
+        logger.error(f"Failed to recompute stats for run {run_id}: {e}")
+        logger.error(traceback.format_exc())
+        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/api/triggers", methods=["GET"])

--- a/backend/server.py
+++ b/backend/server.py
@@ -76,6 +76,15 @@ def _generate_default_backend_specs(backends: list[str]) -> list[dict]:
             "branch": "main",
             "isDefault": False,
         },
+        "wave_4wave_baseline": {
+            "id": "wave-4wave-baseline",
+            "name": "Wave 4-wave (baseline)",
+            "backend": "wave",
+            "backendParam": "wave_4wave_baseline",
+            "remoteRepository": "panditsa/wave",
+            "branch": "4waveasm-256x192x256",
+            "isDefault": False,
+        },
         "wave_8wave": {
             "id": "wave-8wave",
             "name": "Wave (8-wave)",

--- a/backend/server.py
+++ b/backend/server.py
@@ -75,6 +75,10 @@ def _generate_default_backend_specs(backends: list[str]) -> list[dict]:
             "remoteRepository": "iree-org/wave",
             "branch": "main",
             "isDefault": False,
+            "buildMeta": {
+                "rocmLibrariesRepo": "suryajasper/rocm-libraries",
+                "rocmLibrariesBranch": "wave-mxfp4-testing",
+            },
         },
         "wave_4wave_baseline": {
             "id": "wave-4wave-baseline",

--- a/backend/server.py
+++ b/backend/server.py
@@ -75,10 +75,15 @@ def _generate_default_backend_specs(backends: list[str]) -> list[dict]:
             "remoteRepository": "iree-org/wave",
             "branch": "main",
             "isDefault": False,
-            "buildMeta": {
-                "rocmLibrariesRepo": "suryajasper/rocm-libraries",
-                "rocmLibrariesBranch": "wave-mxfp4-testing",
-            },
+        },
+        "wave_8wave": {
+            "id": "wave-8wave",
+            "name": "Wave (8-wave)",
+            "backend": "wave",
+            "backendParam": "wave_8wave",
+            "remoteRepository": "iree-org/wave",
+            "branch": "main",
+            "isDefault": False,
         },
         "wave_4wave_baseline": {
             "id": "wave-4wave-baseline",
@@ -93,13 +98,26 @@ def _generate_default_backend_specs(backends: list[str]) -> list[dict]:
                 "rocmLibrariesBranch": "develop",
             },
         },
-        "wave_8wave": {
-            "id": "wave-8wave",
-            "name": "Wave (8-wave)",
+        "wave_4wave_rocroller": {
+            "id": "wave-4wave-rocroller",
+            "name": "Wave 4-wave (rocroller)",
             "backend": "wave",
-            "backendParam": "wave_8wave",
-            "remoteRepository": "iree-org/wave",
-            "branch": "main",
+            "backendParam": "wave_4wave_rocroller",
+            "remoteRepository": "panditsa/wave",
+            "branch": "4waveasm-256x192x256",
+            "isDefault": False,
+            "buildMeta": {
+                "rocmLibrariesRepo": "suryajasper/rocm-libraries",
+                "rocmLibrariesBranch": "wave-mxfp4-testing",
+            },
+        },
+        "wave_8wave_rocroller": {
+            "id": "wave-8wave-rocroller",
+            "name": "Wave 8-wave (rocroller)",
+            "backend": "wave",
+            "backendParam": "wave_8wave_rocroller",
+            "remoteRepository": "adedespirlet/wave",
+            "branch": "8wavepingpong",
             "isDefault": False,
         },
         "iree": {
@@ -1399,12 +1417,10 @@ def get_tracker_performance_timeline(tracker_id):
     try:
         start_date = request.args.get("start_date")
         end_date = request.args.get("end_date")
-        macrotile = request.args.get("macrotile")  # e.g. "256x192x256"
-        kernel_source = request.args.get("kernel_source")  # e.g. "wave", "aiter", "rocroller"
-
+        
         # Query BenchmarkRunStats for this tracker
         stats = BenchmarkRunStatsDb.query(f"trackerId eq '{tracker_id}'")
-
+        
         # Filter by date range if provided
         if start_date:
             start_dt = datetime.fromisoformat(start_date)
@@ -1412,84 +1428,34 @@ def get_tracker_performance_timeline(tracker_id):
         if end_date:
             end_dt = datetime.fromisoformat(end_date)
             stats = [s for s in stats if s.timestamp <= end_dt]
-
+        
         # Sort by timestamp
         stats.sort(key=lambda s: s.timestamp)
-
+        
         # Transform data for frontend consumption
         timeline = []
         for stat in stats:
+            # Extract backend performance from stat.performance dict
+            # Format: performance[machine][kernel_type][backend] = {avg_tflops, geomean_tflops, ...}
             backends_data = {}
-            available_macrotiles = set()
-            available_kernel_sources = set()
             for machine_data in stat.performance.values():
                 for kernel_type_data in machine_data.values():
                     for backend, metrics in kernel_type_data.items():
-                        for mt in metrics.get("byMacrotile", {}).keys():
-                            available_macrotiles.add(mt)
-                        for ks in metrics.get("byKernelSource", {}).keys():
-                            available_kernel_sources.add(ks)
-
                         if backend not in backends_data:
-                            if macrotile and macrotile in metrics.get("byMacrotile", {}):
-                                backends_data[backend] = metrics["byMacrotile"][macrotile]
-                            elif kernel_source and kernel_source in metrics.get("byKernelSource", {}):
-                                backends_data[backend] = metrics["byKernelSource"][kernel_source]
-                            else:
-                                backends_data[backend] = {
-                                    k: v for k, v in metrics.items()
-                                    if k not in ("byMacrotile", "byKernelSource")
-                                }
-
+                            backends_data[backend] = metrics
+            
             timeline.append({
                 "timestamp": stat.timestamp.isoformat(),
                 "runId": stat.runId,
                 "backends": backends_data,
-                "backendSpecs": stat.backendSpecs if stat.backendSpecs else None,
-                "availableMacrotiles": sorted(available_macrotiles),
-                "availableKernelSources": sorted(available_kernel_sources),
+                "backendSpecs": stat.backendSpecs if stat.backendSpecs else None
             })
-
+        
         return jsonify(timeline)
     except Exception as e:
         logger.error(f"Error getting tracker performance timeline for {tracker_id}: {e}")
         logger.error(traceback.format_exc())
         return jsonify({"error": f"Failed to get tracker performance timeline: {str(e)}"}), 500
-
-
-@app.route("/api/runs/<run_id>/recompute-stats", methods=["POST"])
-def recompute_run_stats(run_id):
-    """Recompute BenchmarkRunStats for a run using the current statistics code."""
-    try:
-        run = WorkflowRunDb.find_by_id(run_id)
-        if not run:
-            return jsonify({"error": f"Run {run_id} not found"}), 404
-
-        kernels = get_artifact_parser(RunType.BENCHMARK).load_data(run.blobName)
-        if not kernels:
-            return jsonify({"error": "Failed to load artifact data"}), 500
-
-        from backend.perf.statistics import compute_performance_statistics
-        performance = compute_performance_statistics(kernels)
-
-        existing = BenchmarkRunStatsDb.query(f"runId eq '{run_id}'")
-        if existing:
-            BenchmarkRunStatsDb.update_by_id(existing[0]._id, {"performance": performance})
-            return jsonify({"message": f"Recomputed stats for run {run_id}", "statsId": existing[0]._id})
-        else:
-            stats = BenchmarkRunStats(
-                _id=str(uuid4()),
-                runId=run_id,
-                timestamp=datetime.now(timezone.utc),
-                machine=run.machine or "unknown",
-                performance=performance,
-            )
-            BenchmarkRunStatsDb.upsert(stats)
-            return jsonify({"message": f"Created stats for run {run_id}", "statsId": stats._id})
-    except Exception as e:
-        logger.error(f"Failed to recompute stats for run {run_id}: {e}")
-        logger.error(traceback.format_exc())
-        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/api/triggers", methods=["GET"])

--- a/backend/storage/types.py
+++ b/backend/storage/types.py
@@ -29,9 +29,9 @@ class WorkflowRunState:
     blobName: str
     timestamp: datetime
     status: str
+    conclusion: str
     numSteps: int
     steps: list[dict]
-    conclusion: Optional[str] = None
     machine: Optional[str] = None
     completed: bool = False
     hasArtifact: bool = False

--- a/benchmark/backends/setup_hipblaslt.sh
+++ b/benchmark/backends/setup_hipblaslt.sh
@@ -9,6 +9,11 @@ echo "Installing hipBLASLt backend dependencies..."
 ROCM_LIBRARIES_REPO="${ROCM_LIBRARIES_REPO:-https://github.com/ROCm/rocm-libraries.git}"
 ROCM_LIBRARIES_BRANCH="${ROCM_LIBRARIES_BRANCH:-develop}"
 
+# Normalize repo to full URL if a short "owner/repo" form was passed
+if [[ "$ROCM_LIBRARIES_REPO" != https://* ]]; then
+    ROCM_LIBRARIES_REPO="https://github.com/${ROCM_LIBRARIES_REPO}.git"
+fi
+
 # GPU_ARCH must be provided by setup.sh
 if [[ -z "$GPU_ARCH" ]]; then
     echo "Error: GPU_ARCH environment variable not set"

--- a/benchmark/docker/Dockerfile
+++ b/benchmark/docker/Dockerfile
@@ -4,6 +4,8 @@ ARG WAVE_REPO=iree-org/wave
 ARG WAVE_BRANCH=main
 ARG BACKENDS=all
 ARG GPU_ARCH
+ARG ROCM_LIBRARIES_REPO=""
+ARG ROCM_LIBRARIES_BRANCH=""
 
 # ============================================================================
 # Stage 1: Base - System Dependencies
@@ -64,6 +66,8 @@ ARG WAVE_REPO
 ARG WAVE_BRANCH
 ARG BACKENDS
 ARG GPU_ARCH
+ARG ROCM_LIBRARIES_REPO
+ARG ROCM_LIBRARIES_BRANCH
 
 # Copy the repository files
 COPY . /workspace
@@ -106,6 +110,12 @@ RUN SETUP_CMD="bash setup.sh"; \
     fi; \
     if [ -n "$GPU_ARCH" ]; then \
         SETUP_CMD="$SETUP_CMD --gpu-arch $GPU_ARCH"; \
+    fi; \
+    if [ -n "$ROCM_LIBRARIES_REPO" ]; then \
+        SETUP_CMD="$SETUP_CMD --rocm-libraries-repo $ROCM_LIBRARIES_REPO"; \
+    fi; \
+    if [ -n "$ROCM_LIBRARIES_BRANCH" ]; then \
+        SETUP_CMD="$SETUP_CMD --rocm-libraries-branch $ROCM_LIBRARIES_BRANCH"; \
     fi; \
     echo "Running: $SETUP_CMD"; \
     eval "$SETUP_CMD" || echo "Warning: Some backends may have failed to install"

--- a/benchmark/docker/build_docker.sh
+++ b/benchmark/docker/build_docker.sh
@@ -11,6 +11,8 @@ GPU_ARCH=""
 BACKENDS=""
 WAVE_REPO=""
 WAVE_BRANCH=""
+ROCM_LIBRARIES_REPO=""
+ROCM_LIBRARIES_BRANCH=""
 IMAGE_TAG="kernel-bench:latest"
 
 # Parse command line arguments
@@ -32,13 +34,25 @@ while [[ $# -gt 0 ]]; do
             WAVE_BRANCH="$2"
             shift 2
             ;;
+        --rocm-libraries-repo)
+            ROCM_LIBRARIES_REPO="$2"
+            shift 2
+            ;;
+        --rocm-libraries-branch)
+            ROCM_LIBRARIES_BRANCH="$2"
+            shift 2
+            ;;
+        --backend-specs-url)
+            # Accepted but not used at build time (passed for informational purposes)
+            shift 2
+            ;;
         -t)
             IMAGE_TAG="$2"
             shift 2
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 --machine <MACHINE> [--backends <backends>] [--wave-repo <repo>] [--wave-branch <branch>] [-t <tag>]"
+            echo "Usage: $0 --machine <MACHINE> [--backends <backends>] [--wave-repo <repo>] [--wave-branch <branch>] [--rocm-libraries-repo <repo>] [--rocm-libraries-branch <branch>] [-t <tag>]"
             exit 1
             ;;
     esac
@@ -88,6 +102,14 @@ fi
 
 if [ -n "$WAVE_BRANCH" ]; then
     BUILD_CMD="$BUILD_CMD --build-arg WAVE_BRANCH=$WAVE_BRANCH"
+fi
+
+if [ -n "$ROCM_LIBRARIES_REPO" ]; then
+    BUILD_CMD="$BUILD_CMD --build-arg ROCM_LIBRARIES_REPO=$ROCM_LIBRARIES_REPO"
+fi
+
+if [ -n "$ROCM_LIBRARIES_BRANCH" ]; then
+    BUILD_CMD="$BUILD_CMD --build-arg ROCM_LIBRARIES_BRANCH=$ROCM_LIBRARIES_BRANCH"
 fi
 
 BUILD_CMD="$BUILD_CMD -t $IMAGE_TAG -f docker/Dockerfile ."

--- a/benchmark/docker/run_bench.sh
+++ b/benchmark/docker/run_bench.sh
@@ -12,6 +12,7 @@ BACKENDS="all"
 KERNEL_TYPES="all"
 PROBLEMS_URL=""
 TUNED_CONFIGS_URL=""
+BACKEND_SPECS_URL=""
 OUTPUT_DIR=""
 
 # Parse command line arguments
@@ -39,6 +40,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --tuned-configs-url)
             TUNED_CONFIGS_URL="$2"
+            shift 2
+            ;;
+        --backend-specs-url)
+            BACKEND_SPECS_URL="$2"
             shift 2
             ;;
         -o)
@@ -111,6 +116,24 @@ else
     TUNED_ARG=""
 fi
 
+# Build env vars for benchmark class overrides from backend specs
+BENCH_CLASS_ENV_ARGS=""
+if [ -n "$BACKEND_SPECS_URL" ]; then
+    SPECS=$(curl -sL "$BACKEND_SPECS_URL")
+    while IFS= read -r line; do
+        BENCH_CLASS_ENV_ARGS="$BENCH_CLASS_ENV_ARGS -e $line"
+    done < <(echo "$SPECS" | python3 -c "
+import json, sys, re
+specs = json.load(sys.stdin)
+for s in specs:
+    cls = s.get('benchmarkClass', '')
+    param = s.get('backendParam', '') or s.get('backend', '')
+    if cls and param:
+        key = 'WAVE_BENCHMARK_CLASS_' + re.sub(r'[^A-Z0-9]', '_', param.upper())
+        print(f'{key}={cls}')
+" 2>/dev/null)
+fi
+
 # Execute the docker command directly using a here-document
 docker run --rm \
     --device=/dev/kfd \
@@ -120,6 +143,7 @@ docker run --rm \
     --cap-add=SYS_PTRACE \
     --security-opt seccomp=unconfined \
     -e WAVE_CACHE_ON=0 \
+    $BENCH_CLASS_ENV_ARGS \
     -v "$OUTPUT_DIR:/data" \
     -w /workspace \
     "$IMAGE" \

--- a/benchmark/kernel_bench/core/runner.py
+++ b/benchmark/kernel_bench/core/runner.py
@@ -112,7 +112,15 @@ class BenchmarkRunner:
 
     def _load_benches(self):
         """Create benchmark instances for all configurations."""
-        benches = [self._create_benchmark(tag, config) for tag, config in self.configs]
+        from kernel_bench.core.base import BENCHMARKS
+        bench_cls = BENCHMARKS.get(self.kernel_type, {}).get(self.backend)
+        expanded = []
+        for tag, config in self.configs:
+            if bench_cls is not None:
+                expanded.extend(bench_cls.expand_configs(tag, config))
+            else:
+                expanded.append((tag, config))
+        benches = [self._create_benchmark(tag, config) for tag, config in expanded]
         self._benches = [bench for bench in benches if bench]
         if len(self._benches) != len(self.configs):
             self.logger.info(

--- a/benchmark/kernel_bench/core/template.py
+++ b/benchmark/kernel_bench/core/template.py
@@ -143,7 +143,7 @@ class KernelBenchmark(ABC):
         """Validate numerical accuracy of kernel before benchmarking"""
         return True
 
-    def get_bench_result(self, runtime_us: float, ok: bool):
+    def get_bench_result(self, runtime_us: float, ok: bool, error_msg: str = None):
         arithmetic_intensity, tflops_per_second = get_kernel_perf_stats(
             self.config, runtime_us if ok else math.inf
         )
@@ -164,6 +164,7 @@ class KernelBenchmark(ABC):
             arithmetic_intensity=round(arithmetic_intensity, 4),
             tflops=round(tflops_per_second, 4),
             ok=ok,
+            error_msg=error_msg,
         )
 
     @property
@@ -184,6 +185,13 @@ class KernelBenchmark(ABC):
     def update_parameter_values(self, param_values: dict[str, int]):
         for name, val in param_values.items():
             self.tuning_spec.set_parameter(name, val)
+
+    @classmethod
+    def expand_configs(cls, tag: str, config: OpConfig) -> List[Tuple[str, OpConfig]]:
+        """Expand a single (tag, config) into multiple entries, e.g. one per macrotile.
+        Override in subclasses that need to sweep multiple variants per problem shape.
+        Default: identity (one entry per config)."""
+        return [(tag, config)]
 
     @abstractmethod
     def run_bench(

--- a/benchmark/kernel_bench/core/template.py
+++ b/benchmark/kernel_bench/core/template.py
@@ -143,7 +143,7 @@ class KernelBenchmark(ABC):
         """Validate numerical accuracy of kernel before benchmarking"""
         return True
 
-    def get_bench_result(self, runtime_us: float, ok: bool, error_msg: str = None):
+    def get_bench_result(self, runtime_us: float, ok: bool, error_msg: str = None, kernel_source: str = None):
         arithmetic_intensity, tflops_per_second = get_kernel_perf_stats(
             self.config, runtime_us if ok else math.inf
         )
@@ -165,6 +165,7 @@ class KernelBenchmark(ABC):
             tflops=round(tflops_per_second, 4),
             ok=ok,
             error_msg=error_msg,
+            kernel_source=kernel_source,
         )
 
     @property
@@ -230,7 +231,7 @@ class IREEKernelBenchmark(KernelBenchmark):
             profiler_dump_path=tt_dump_dir,
             kernel_regex=self.kernel_regex
         )
-        return self.get_bench_result(runtime_us, ok)
+        return self.get_bench_result(runtime_us, ok, kernel_source="wave")
 
     def run_bench(self, device, num_iterations=1, timeout=None):
         mlir_dir = self.path_config.mlir_for(self.kernel_type, self.backend)

--- a/benchmark/kernel_bench/kernels/gemm/__init__.py
+++ b/benchmark/kernel_bench/kernels/gemm/__init__.py
@@ -4,47 +4,89 @@ import warnings
 # Import config from new location
 from kernel_bench.config.types.gemm import GemmConfig
 
+
 # Lazy imports with guards for backends
 def _get_backend_classes():
     """Lazily import backend classes only when needed"""
     backends = {}
-    
+
     try:
         from .backends.wave_gemm import WaveGemmBenchmark
-        backends['wave'] = WaveGemmBenchmark
+
+        backends["wave"] = WaveGemmBenchmark
     except Exception as e:
         warnings.warn(f"Wave GEMM backend not available: {e}")
         WaveGemmBenchmark = None
-    
+
+    try:
+        from .backends.wave_mxfp4_gemm_4wave import WaveMxfp4Gemm4WaveBenchmark
+
+        backends["wave_4wave"] = WaveMxfp4Gemm4WaveBenchmark
+    except Exception as e:
+        warnings.warn(f"Wave MXFP4 4-wave GEMM backend not available: {e}")
+
+    try:
+        from .backends.wave_mxfp4_gemm_8wave import WaveMxfp4Gemm8WaveBenchmark
+
+        backends["wave_8wave"] = WaveMxfp4Gemm8WaveBenchmark
+    except Exception as e:
+        warnings.warn(f"Wave MXFP4 8-wave GEMM backend not available: {e}")
+
     try:
         from .backends.iree_gemm import IREEGemmBenchmark
-        backends['iree'] = IREEGemmBenchmark
+
+        backends["iree"] = IREEGemmBenchmark
     except Exception as e:
         warnings.warn(f"IREE GEMM backend not available: {e}")
         IREEGemmBenchmark = None
 
     try:
         from .backends.torch_gemm import TorchGemmBenchmark
-        backends['torch'] = TorchGemmBenchmark
+
+        backends["torch"] = TorchGemmBenchmark
     except Exception as e:
         warnings.warn(f"Torch GEMM backend not available: {e}")
         TorchGemmBenchmark = None
-        
+
     try:
         from .backends.triton_gemm import TritonGemmBenchmark
-        backends['triton'] = TritonGemmBenchmark
+
+        backends["triton"] = TritonGemmBenchmark
     except Exception as e:
         warnings.warn(f"Triton GEMM backend not available: {e}")
         TritonGemmBenchmark = None
-        
+
     try:
         from .backends.hipblaslt_gemm import HipBLASLtGemmBenchmark
-        backends['hipblaslt'] = HipBLASLtGemmBenchmark
+
+        backends["hipblaslt"] = HipBLASLtGemmBenchmark
     except Exception as e:
         warnings.warn(f"hipBLASLt GEMM backend not available: {e}")
         HipBLASLtGemmBenchmark = None
-        
+
+    try:
+        from .backends.wave_mxfp4_gemm_4wave_rocroller import WaveMxfp4Gemm4WaveRocrollerBenchmark
+
+        backends["wave_4wave_rocroller"] = WaveMxfp4Gemm4WaveRocrollerBenchmark
+    except Exception as e:
+        warnings.warn(f"Wave MXFP4 4-wave rocroller GEMM backend not available: {e}")
+
+    try:
+        from .backends.wave_mxfp4_gemm_4wave_baseline import WaveMxfp4Gemm4WaveBaselineBenchmark
+
+        backends["wave_4wave_baseline"] = WaveMxfp4Gemm4WaveBaselineBenchmark
+    except Exception as e:
+        warnings.warn(f"Wave MXFP4 4-wave baseline GEMM backend not available: {e}")
+
+    try:
+        from .backends.wave_mxfp4_gemm_8wave_rocroller import WaveMxfp4Gemm8WaveRocrollerBenchmark
+
+        backends["wave_8wave_rocroller"] = WaveMxfp4Gemm8WaveRocrollerBenchmark
+    except Exception as e:
+        warnings.warn(f"Wave MXFP4 8-wave rocroller GEMM backend not available: {e}")
+
     return backends
+
 
 from .problems import (
     get_80k_gemm_configs,
@@ -58,20 +100,15 @@ from .problems import (
     get_tk_gemm_configs,
     get_b200_gemm_configs,
     get_trial_configs,
+    get_mxfp4_gemms,
 )
 
 
 def get_default_gemm_configs(kernel_type: str, backend_name: str):
     configs = []
-    configs += get_meta_gemms()
-    configs += get_gemm_configs("f16")
-    configs += get_gemm_configs("bf16")
-    configs += get_trial_configs()
-    configs += get_gemm_configs("f8")
-    configs += get_paper_gemms()
-    configs += get_80k_gemm_configs(100)
+    configs += get_mxfp4_gemms(max_per_tag=100)
     return configs
 
 
-# Dynamically build the GEMM_BENCH dictionary with available backends     
+# Dynamically build the GEMM_BENCH dictionary with available backends
 GEMM_BENCH = {"gemm": _get_backend_classes()}

--- a/benchmark/kernel_bench/kernels/gemm/__init__.py
+++ b/benchmark/kernel_bench/kernels/gemm/__init__.py
@@ -1,4 +1,6 @@
 from typing import List, Tuple
+import os
+import re
 import sys
 import warnings
 
@@ -87,9 +89,17 @@ def _get_backend_classes():
         warnings.warn(f"Wave MXFP4 8-wave rocroller GEMM backend not available: {e}")
 
     # Auto-register any unknown wave_* backend params passed via --backend CLI arg.
-    # This allows custom wave specs (e.g. wave_sanket) created in the dashboard to
-    # run without requiring a hardcoded entry here.
+    # The benchmark class is read from env var WAVE_BENCHMARK_CLASS_<PARAM> (set by
+    # run_bench.sh from the backend spec's benchmarkClass field). Falls back to
+    # WaveGemmBenchmark. Uses a direct alias (not a new type) to stay picklable.
     try:
+        _class_map = {
+            "WaveGemmBenchmark": backends.get("wave"),
+            "WaveMxfp4Gemm4WaveBenchmark": backends.get("wave_4wave"),
+            "WaveMxfp4Gemm8WaveBenchmark": backends.get("wave_8wave"),
+            "WaveMxfp4Gemm4WaveRocrollerBenchmark": backends.get("wave_4wave_rocroller"),
+            "WaveMxfp4Gemm4WaveBaselineBenchmark": backends.get("wave_4wave_baseline"),
+        }
         requested = []
         for i, arg in enumerate(sys.argv):
             if arg in ("--backend", "--backends") and i + 1 < len(sys.argv):
@@ -99,12 +109,12 @@ def _get_backend_classes():
         for param in requested:
             param = param.strip()
             if param.startswith("wave_") and param not in backends:
-                base_cls = backends.get("wave")
-                if base_cls is not None:
-                    backends[param] = type(param, (base_cls,), {})
-                    warnings.warn(
-                        f"Auto-registered unknown wave backend '{param}' as WaveGemmBenchmark variant"
-                    )
+                env_key = "WAVE_BENCHMARK_CLASS_" + re.sub(r"[^A-Z0-9]", "_", param.upper())
+                class_name = os.environ.get(env_key, "WaveGemmBenchmark")
+                cls = _class_map.get(class_name) or backends.get("wave")
+                if cls is not None:
+                    backends[param] = cls
+                    warnings.warn(f"Auto-registered unknown wave backend '{param}' as {class_name}")
     except Exception as e:
         warnings.warn(f"Could not auto-register custom wave backends: {e}")
 

--- a/benchmark/kernel_bench/kernels/gemm/__init__.py
+++ b/benchmark/kernel_bench/kernels/gemm/__init__.py
@@ -1,4 +1,5 @@
 from typing import List, Tuple
+import sys
 import warnings
 
 # Import config from new location
@@ -84,6 +85,28 @@ def _get_backend_classes():
         backends["wave_8wave_rocroller"] = WaveMxfp4Gemm8WaveRocrollerBenchmark
     except Exception as e:
         warnings.warn(f"Wave MXFP4 8-wave rocroller GEMM backend not available: {e}")
+
+    # Auto-register any unknown wave_* backend params passed via --backend CLI arg.
+    # This allows custom wave specs (e.g. wave_sanket) created in the dashboard to
+    # run without requiring a hardcoded entry here.
+    try:
+        requested = []
+        for i, arg in enumerate(sys.argv):
+            if arg in ("--backend", "--backends") and i + 1 < len(sys.argv):
+                requested = sys.argv[i + 1].split(",")
+            elif arg.startswith("--backend=") or arg.startswith("--backends="):
+                requested = arg.split("=", 1)[1].split(",")
+        for param in requested:
+            param = param.strip()
+            if param.startswith("wave_") and param not in backends:
+                base_cls = backends.get("wave")
+                if base_cls is not None:
+                    backends[param] = type(param, (base_cls,), {})
+                    warnings.warn(
+                        f"Auto-registered unknown wave backend '{param}' as WaveGemmBenchmark variant"
+                    )
+    except Exception as e:
+        warnings.warn(f"Could not auto-register custom wave backends: {e}")
 
     return backends
 

--- a/benchmark/kernel_bench/kernels/gemm/backends/hipblaslt_gemm.py
+++ b/benchmark/kernel_bench/kernels/gemm/backends/hipblaslt_gemm.py
@@ -54,6 +54,7 @@ class HipBLASLtGemmBenchmark(KernelBenchmark):
             # Parse the output
             mean_time_us = parse_hipblaslt_us(result.stdout)
             hyperparams = parse_hipblaslt_block_sizes(result.stdout)
+            kernel_source = _parse_kernel_source(result.stdout, result.stderr)
 
             if mean_time_us is None:
                 self.logger.error(
@@ -64,9 +65,9 @@ class HipBLASLtGemmBenchmark(KernelBenchmark):
                 )
                 return self.get_bench_result(0.0, False)
 
-            result = self.get_bench_result(mean_time_us, True)
-            result.tuning_config = hyperparams
-            return result
+            bench_result = self.get_bench_result(mean_time_us, True, kernel_source=kernel_source)
+            bench_result.tuning_config = hyperparams
+            return bench_result
 
         except subprocess.TimeoutExpired:
             self.logger.error("Benchmark timed out")
@@ -74,6 +75,34 @@ class HipBLASLtGemmBenchmark(KernelBenchmark):
         except Exception as e:
             self.logger.error(f"Error running benchmark: {e}")
             return self.get_bench_result(0.0, False)
+
+
+def _parse_kernel_source(stdout: str, stderr: str) -> str | None:
+    """
+    Determine kernel source from hipblaslt-bench output.
+
+    Primary: parse '[KERNEL_SOURCE] <source>' from stderr.
+    Fallback: infer from 'Loading kernel from cache: <symbol>' in stdout.
+    """
+    for line in stderr.splitlines():
+        s = line.strip()
+        if s.startswith("[KERNEL_SOURCE]"):
+            parts = s.split()
+            if len(parts) >= 2:
+                src = parts[1].lower()
+                if src in ("wave", "aiter", "rocroller"):
+                    return src
+    # Fallback: symbol name in stdout contains backend identifier
+    for line in stdout.splitlines():
+        s = line.strip()
+        if s.startswith("Loading kernel from cache:"):
+            symbol = s.split(":", 1)[1].strip()
+            if "aiter" in symbol:
+                return "aiter"
+            if "rocroller" in symbol.lower():
+                return "rocroller"
+            return "wave"
+    return None
 
 
 def parse_hipblaslt_us(output: str, row_index: Optional[int] = None) -> float:

--- a/benchmark/kernel_bench/utils/bench_utils.py
+++ b/benchmark/kernel_bench/utils/bench_utils.py
@@ -32,6 +32,7 @@ class BenchmarkResult:
     tflops: float
     ok: bool
     error_msg: Optional[str] = None
+    kernel_source: Optional[str] = None  # e.g. "wave", "aiter", "rocroller"
 
     def __eq__(self, other):
         if isinstance(other, BenchmarkResult):

--- a/benchmark/kernel_bench/utils/bench_utils.py
+++ b/benchmark/kernel_bench/utils/bench_utils.py
@@ -31,6 +31,7 @@ class BenchmarkResult:
     arithmetic_intensity: float
     tflops: float
     ok: bool
+    error_msg: Optional[str] = None
 
     def __eq__(self, other):
         if isinstance(other, BenchmarkResult):

--- a/benchmark/setup.sh
+++ b/benchmark/setup.sh
@@ -14,6 +14,10 @@ WAVE_BRANCH=""
 INSTALL_FROM_SOURCE=false
 BACKENDS="all"  # Default to all backends
 GPU_ARCH="${GPU_ARCH:-}"  # No default, required for hipblaslt/all backends
+ROCM_LIBRARIES_REPO="${ROCM_LIBRARIES_REPO:-}"  # Override for hipBLASLt source
+ROCM_LIBRARIES_BRANCH="${ROCM_LIBRARIES_BRANCH:-}"
+STRICT=false  # If true, exit non-zero when any requested backend fails (e.g. Docker/CI)
+BACKEND_SPECS_FILE=""  # Optional JSON file with per-backend specs (repo/branch overrides)
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -34,6 +38,18 @@ while [[ $# -gt 0 ]]; do
             WAVE_BRANCH="$2"
             shift 2
             ;;
+        --rocm-libraries-repo)
+            ROCM_LIBRARIES_REPO="$2"
+            shift 2
+            ;;
+        --rocm-libraries-branch)
+            ROCM_LIBRARIES_BRANCH="$2"
+            shift 2
+            ;;
+        --backend-specs-file)
+            BACKEND_SPECS_FILE="$2"
+            shift 2
+            ;;
         --venv-path)
             VENV_PATH="$2"
             USE_VENV=true
@@ -42,6 +58,10 @@ while [[ $# -gt 0 ]]; do
         --gpu-arch|--gpu_arch)
             GPU_ARCH="$2"
             shift 2
+            ;;
+        --strict)
+            STRICT=true
+            shift
             ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
@@ -56,6 +76,7 @@ while [[ $# -gt 0 ]]; do
             echo "                         installs into the existing Python environment."
             echo "  --gpu-arch ARCH        GPU architecture for hipBLASLt (REQUIRED for hipblaslt/all)"
             echo "                         Examples: gfx950, gfx942, gfx90a, gfx950;gfx942"
+            echo "  --strict               Exit with failure if any backend fails to install"
             echo "  -h, --help             Show this help message"
             echo ""
             echo "Examples:"
@@ -104,15 +125,24 @@ if [[ "$BACKENDS" == "all" ]]; then
 else
     IFS=',' read -ra BACKEND_LIST <<< "$BACKENDS"
     
-    # Always ensure Wave is in the list (required dependency for other backends)
+    # Ensure Wave gets installed when needed. Plain "wave" counts; any backend
+    # named wave_* (e.g. wave_4wave_rocroller) installs Wave inside its own case
+    # so we must not prepend a separate "wave" entry — that runs Wave first and
+    # can fail strict builds even when the user only asked for wave_* (hipBLASLt
+    # then still succeeds, yielding a confusing split summary).
     WAVE_IN_LIST=false
     for backend in "${BACKEND_LIST[@]}"; do
-        if [[ "$backend" == "wave" ]]; then
+        backend_trim=$(echo "$backend" | xargs)
+        if [[ "$backend_trim" == "wave" ]]; then
+            WAVE_IN_LIST=true
+            break
+        fi
+        if [[ "$backend_trim" == wave_* ]]; then
             WAVE_IN_LIST=true
             break
         fi
     done
-    
+
     if [[ "$WAVE_IN_LIST" == "false" ]]; then
         echo "Note: Adding Wave backend (required dependency)"
         BACKEND_LIST=("wave" "${BACKEND_LIST[@]}")
@@ -122,13 +152,13 @@ else
 fi
 echo ""
 
-# Validate GPU_ARCH is provided when hipBLASLt is in the backend list
+# Validate GPU_ARCH is provided when hipBLASLt or rocroller backends are in the list
 REQUIRES_GPU_ARCH=false
 if [[ "$BACKENDS" == "all" ]]; then
     REQUIRES_GPU_ARCH=true
 else
     for backend in "${BACKEND_LIST[@]}"; do
-        if [[ "$backend" == "hipblaslt" ]]; then
+        if [[ "$backend" == "hipblaslt" || "$backend" == *"rocroller"* ]]; then
             REQUIRES_GPU_ARCH=true
             break
         fi
@@ -153,6 +183,29 @@ if [[ -n "$GPU_ARCH" ]]; then
     export GPU_ARCH
     echo "GPU Architecture: $GPU_ARCH"
 fi
+
+# Export rocm-libraries overrides so setup_hipblaslt.sh picks them up
+if [[ -n "$ROCM_LIBRARIES_REPO" ]]; then
+    if [[ "$ROCM_LIBRARIES_REPO" != https://* ]]; then
+        ROCM_LIBRARIES_REPO="https://github.com/${ROCM_LIBRARIES_REPO}.git"
+    fi
+    export ROCM_LIBRARIES_REPO
+    echo "ROCm Libraries repo override: $ROCM_LIBRARIES_REPO"
+fi
+if [[ -n "$ROCM_LIBRARIES_BRANCH" ]]; then
+    export ROCM_LIBRARIES_BRANCH
+    echo "ROCm Libraries branch override: $ROCM_LIBRARIES_BRANCH"
+fi
+
+# Enable WaveASM build for wave rocroller backends (requires LLVM from ROCm)
+for backend in "${BACKEND_LIST[@]}"; do
+    if [[ "$backend" == *"4wave"* || "$backend" == *"8wave"* ]]; then
+        export WAVE_BUILD_WAVEASM=1
+        export WAVE_LLVM_DIR="/opt/rocm/llvm"
+        echo "WaveASM build enabled for wave backend ($backend)"
+        break
+    fi
+done
 
 # Create and activate virtual environment only if requested
 if [[ "$USE_VENV" == "true" ]]; then
@@ -179,6 +232,24 @@ echo ""
 # Track which backends succeeded/failed
 declare -a SUCCESSFUL_BACKENDS=()
 declare -a FAILED_BACKENDS=()
+declare -A WAVE_INSTALLED_DIRS=()  # Map of install_dir -> true (tracks per-variant installations)
+
+# Look up per-backend wave repo from backend specs file
+get_spec_field_for_backend() {
+    local backend="$1"
+    local field="$2"
+    if [[ -n "$BACKEND_SPECS_FILE" && -f "$BACKEND_SPECS_FILE" ]]; then
+        python3 -c "
+import json, sys
+specs = json.load(open('$BACKEND_SPECS_FILE'))
+for s in specs:
+    bp = s.get('backendParam', s.get('backend', ''))
+    if bp == '$backend':
+        print(s.get('$field', ''))
+        break
+" 2>/dev/null
+    fi
+}
 
 # Install each backend
 for backend in "${BACKEND_LIST[@]}"; do
@@ -189,7 +260,145 @@ for backend in "${BACKEND_LIST[@]}"; do
     echo "-----------------------------------"
     
     case "$backend" in
-        wave)
+        wave_4wave_baseline)
+            echo "$backend requires Wave (wave_lang) + hipblaslt from ROCm/rocm-libraries @ develop (aiter baseline, no rocroller)"
+
+            # Determine per-backend wave repo/branch from specs file or defaults
+            BACKEND_WAVE_REPO=$(get_spec_field_for_backend "$backend" "remoteRepository")
+            BACKEND_WAVE_BRANCH=$(get_spec_field_for_backend "$backend" "branch")
+
+            if [[ -z "$BACKEND_WAVE_REPO" ]]; then
+                BACKEND_WAVE_REPO="$WAVE_REPO"
+            fi
+            if [[ -z "$BACKEND_WAVE_BRANCH" ]]; then
+                BACKEND_WAVE_BRANCH="$WAVE_BRANCH"
+            fi
+
+            # Install wave into a per-backend directory
+            WAVE_INSTALL_DIR="wave-${backend}"
+            if [[ -z "${WAVE_INSTALLED_DIRS[$WAVE_INSTALL_DIR]+_}" ]]; then
+                if [[ ! -f "backends/setup_wave.sh" ]]; then
+                    echo "Error: setup_wave.sh not found in backends/"
+                    FAILED_BACKENDS+=("$backend")
+                    continue
+                fi
+                if [[ -n "$BACKEND_WAVE_REPO" && -n "$BACKEND_WAVE_BRANCH" ]]; then
+                    echo "Installing wave for $backend: $BACKEND_WAVE_REPO @ $BACKEND_WAVE_BRANCH -> $WAVE_INSTALL_DIR"
+                    if ! bash backends/setup_wave.sh "$BACKEND_WAVE_REPO" "$BACKEND_WAVE_BRANCH" "$WAVE_INSTALL_DIR"; then
+                        echo "Warning: Wave install failed for $backend"
+                        FAILED_BACKENDS+=("$backend")
+                        continue
+                    fi
+                elif [[ "$INSTALL_FROM_SOURCE" == "true" ]]; then
+                    echo "Installing wave for $backend: $WAVE_REPO @ $WAVE_BRANCH -> $WAVE_INSTALL_DIR"
+                    if ! bash backends/setup_wave.sh "$WAVE_REPO" "$WAVE_BRANCH" "$WAVE_INSTALL_DIR"; then
+                        echo "Warning: Wave install failed for $backend"
+                        FAILED_BACKENDS+=("$backend")
+                        continue
+                    fi
+                else
+                    echo "Installing wave for $backend (default) -> $WAVE_INSTALL_DIR"
+                    if ! bash backends/setup_wave.sh "" "" "$WAVE_INSTALL_DIR"; then
+                        echo "Warning: Wave install failed for $backend"
+                        FAILED_BACKENDS+=("$backend")
+                        continue
+                    fi
+                fi
+                WAVE_INSTALLED_DIRS[$WAVE_INSTALL_DIR]=true
+            else
+                echo "Wave already installed at $WAVE_INSTALL_DIR, skipping"
+            fi
+
+            if [[ ! -f "backends/setup_hipblaslt.sh" ]]; then
+                echo "Error: setup_hipblaslt.sh not found in backends/"
+                FAILED_BACKENDS+=("$backend")
+                continue
+            fi
+
+            # Use ROCM_LIBRARIES_REPO/BRANCH from CLI args, defaulting to ROCm/rocm-libraries @ develop
+            BASELINE_ROCM_REPO="${ROCM_LIBRARIES_REPO:-https://github.com/ROCm/rocm-libraries.git}"
+            BASELINE_ROCM_BRANCH="${ROCM_LIBRARIES_BRANCH:-develop}"
+            if ROCM_LIBRARIES_REPO="$BASELINE_ROCM_REPO" \
+               ROCM_LIBRARIES_BRANCH="$BASELINE_ROCM_BRANCH" \
+               bash backends/setup_hipblaslt.sh; then
+                SUCCESSFUL_BACKENDS+=("$backend")
+            else
+                echo "Warning: Failed to install $backend backend"
+                FAILED_BACKENDS+=("$backend")
+            fi
+            ;;
+
+        wave_4wave_rocroller|wave_8wave_rocroller)
+            echo "$backend requires Wave (wave_lang) + hipblaslt with rocroller support"
+
+            # Determine per-backend wave repo/branch from specs file or defaults
+            BACKEND_WAVE_REPO=$(get_spec_field_for_backend "$backend" "remoteRepository")
+            BACKEND_WAVE_BRANCH=$(get_spec_field_for_backend "$backend" "branch")
+
+            # Fall back to CLI args if no spec found
+            if [[ -z "$BACKEND_WAVE_REPO" ]]; then
+                BACKEND_WAVE_REPO="$WAVE_REPO"
+            fi
+            if [[ -z "$BACKEND_WAVE_BRANCH" ]]; then
+                BACKEND_WAVE_BRANCH="$WAVE_BRANCH"
+            fi
+
+            # Install wave into a per-backend directory
+            WAVE_INSTALL_DIR="wave-${backend}"
+            if [[ -z "${WAVE_INSTALLED_DIRS[$WAVE_INSTALL_DIR]+_}" ]]; then
+                if [[ ! -f "backends/setup_wave.sh" ]]; then
+                    echo "Error: setup_wave.sh not found in backends/"
+                    FAILED_BACKENDS+=("$backend")
+                    continue
+                fi
+                if [[ -n "$BACKEND_WAVE_REPO" && -n "$BACKEND_WAVE_BRANCH" ]]; then
+                    echo "Installing wave for $backend: $BACKEND_WAVE_REPO @ $BACKEND_WAVE_BRANCH -> $WAVE_INSTALL_DIR"
+                    if ! bash backends/setup_wave.sh "$BACKEND_WAVE_REPO" "$BACKEND_WAVE_BRANCH" "$WAVE_INSTALL_DIR"; then
+                        echo "Warning: Wave install failed for $backend"
+                        FAILED_BACKENDS+=("$backend")
+                        continue
+                    fi
+                elif [[ "$INSTALL_FROM_SOURCE" == "true" ]]; then
+                    echo "Installing wave for $backend: $WAVE_REPO @ $WAVE_BRANCH -> $WAVE_INSTALL_DIR"
+                    if ! bash backends/setup_wave.sh "$WAVE_REPO" "$WAVE_BRANCH" "$WAVE_INSTALL_DIR"; then
+                        echo "Warning: Wave install failed for $backend"
+                        FAILED_BACKENDS+=("$backend")
+                        continue
+                    fi
+                else
+                    echo "Installing wave for $backend (default) -> $WAVE_INSTALL_DIR"
+                    if ! bash backends/setup_wave.sh "" "" "$WAVE_INSTALL_DIR"; then
+                        echo "Warning: Wave install failed for $backend"
+                        FAILED_BACKENDS+=("$backend")
+                        continue
+                    fi
+                fi
+                WAVE_INSTALLED_DIRS[$WAVE_INSTALL_DIR]=true
+            else
+                echo "Wave already installed at $WAVE_INSTALL_DIR, skipping"
+            fi
+
+            if [[ ! -f "backends/setup_hipblaslt.sh" ]]; then
+                echo "Error: setup_hipblaslt.sh not found in backends/"
+                FAILED_BACKENDS+=("$backend")
+                continue
+            fi
+
+            if bash backends/setup_hipblaslt.sh; then
+                SUCCESSFUL_BACKENDS+=("$backend")
+            else
+                echo "Warning: Failed to install $backend backend"
+                FAILED_BACKENDS+=("$backend")
+            fi
+            ;;
+
+        wave*)
+            if [[ -n "${WAVE_INSTALLED_DIRS[wave]+_}" ]]; then
+                echo "Wave already installed at /workspace/wave, skipping reinstall for $backend"
+                SUCCESSFUL_BACKENDS+=("$backend")
+                continue
+            fi
+
             if [[ ! -f "backends/setup_wave.sh" ]]; then
                 echo "Error: setup_wave.sh not found in backends/"
                 FAILED_BACKENDS+=("$backend")
@@ -197,15 +406,17 @@ for backend in "${BACKEND_LIST[@]}"; do
             fi
             
             if [[ "$INSTALL_FROM_SOURCE" == "true" ]]; then
-                if bash backends/setup_wave.sh "$WAVE_REPO" "$WAVE_BRANCH"; then
+                if bash backends/setup_wave.sh "$WAVE_REPO" "$WAVE_BRANCH" "wave"; then
                     SUCCESSFUL_BACKENDS+=("$backend")
+                    WAVE_INSTALLED_DIRS[wave]=true
                 else
                     echo "Warning: Failed to install $backend backend"
                     FAILED_BACKENDS+=("$backend")
                 fi
             else
-                if bash backends/setup_wave.sh; then
+                if bash backends/setup_wave.sh "" "" "wave"; then
                     SUCCESSFUL_BACKENDS+=("$backend")
+                    WAVE_INSTALLED_DIRS[wave]=true
                 else
                     echo "Warning: Failed to install $backend backend"
                     FAILED_BACKENDS+=("$backend")
@@ -272,10 +483,10 @@ for backend in "${BACKEND_LIST[@]}"; do
                 FAILED_BACKENDS+=("$backend")
             fi
             ;;
-            
+
         *)
             echo "Error: Unknown backend '$backend'"
-            echo "Available backends: wave, torch, triton, iree, hipblaslt"
+            echo "Available backends: wave, torch, triton, iree, hipblaslt, wave_4wave_rocroller, wave_8wave_rocroller"
             FAILED_BACKENDS+=("$backend")
             ;;
     esac
@@ -321,5 +532,9 @@ echo ""
 
 if [[ ${#FAILED_BACKENDS[@]} -gt 0 ]]; then
     echo "Warning: Some backends failed to install. The benchmark suite will automatically skip these backends."
-    exit 0  # Don't fail the entire setup if some backends fail
+    if [[ "$STRICT" == "true" ]]; then
+        echo "Error: --strict was set; failing setup because backends failed: ${FAILED_BACKENDS[*]}"
+        exit 1
+    fi
+    exit 0
 fi

--- a/dashboard/src/components/DashboardRenderer.tsx
+++ b/dashboard/src/components/DashboardRenderer.tsx
@@ -34,6 +34,7 @@ interface DashboardRendererProps {
   isTrackerDashboard?: boolean;
   profilingManifest?: Record<string, any> | null;
   blobName?: string | null;
+  latestBackendSpecs?: Record<string, any> | null;
 }
 
 function toRGLLayout(layout: WidgetLayout[]): LayoutItem[] {
@@ -79,6 +80,7 @@ export default function DashboardRenderer({
   isTrackerDashboard = false,
   profilingManifest,
   blobName,
+  latestBackendSpecs,
 }: DashboardRendererProps) {
   const { isAuthenticated, requestAuth } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
@@ -305,6 +307,7 @@ export default function DashboardRenderer({
           onUpdateFilter={handleUpdateFilter}
           onDeleteFilter={handleDeleteFilter}
           colorByFields={colorByFields}
+          latestBackendSpecs={latestBackendSpecs}
         />
       )}
 

--- a/dashboard/src/components/DashboardRenderer.tsx
+++ b/dashboard/src/components/DashboardRenderer.tsx
@@ -22,7 +22,11 @@ import EditToolbar from "./DashboardEditor/EditToolbar";
 import WidgetCatalog from "./DashboardEditor/WidgetCatalog";
 import WidgetConfigModal from "./DashboardEditor/WidgetConfigModal";
 import CsvDownloadModal from "./Modals/CsvDownloadModal";
+import KernelView from "./Kernels/KernelView";
 import { useAuth } from "../contexts/AuthContext";
+import { useKernelDims } from "../contexts/KernelTypesContext";
+import { getDimensionsForKernelType } from "../utils/utils";
+import type { Kernel } from "../types";
 
 interface DashboardRendererProps {
   config: DashboardConfig;
@@ -83,6 +87,8 @@ export default function DashboardRenderer({
   latestBackendSpecs,
 }: DashboardRendererProps) {
   const { isAuthenticated, requestAuth } = useAuth();
+  const kernelDims = useKernelDims();
+  const [selectedKernelId, setSelectedKernelId] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const configSnapshotRef = useRef<DashboardConfig | null>(null);
   const [showCatalog, setShowCatalog] = useState(false);
@@ -95,6 +101,23 @@ export default function DashboardRenderer({
   const { width, containerRef, mounted } = useContainerWidth();
 
   const rglLayout = useMemo(() => toRGLLayout(config.layout), [config.layout]);
+
+  const allKernels = rawData as unknown as Kernel[];
+  const selectedKernel = useMemo(
+    () => allKernels.find((k) => k.id === selectedKernelId),
+    [allKernels, selectedKernelId]
+  );
+  const sameShapeKernels = useMemo(() => {
+    if (!selectedKernel) return [];
+    const dims = getDimensionsForKernelType(selectedKernel.kernelType, kernelDims, selectedKernel.shape);
+    return allKernels.filter((k) => {
+      if (k.kernelType !== selectedKernel.kernelType) return false;
+      if (k.dtype !== selectedKernel.dtype) return false;
+      return dims.every((dimName) =>
+        dimName === "dtype" ? k.dtype === selectedKernel.dtype : k.shape[dimName] === selectedKernel.shape[dimName]
+      );
+    });
+  }, [allKernels, selectedKernel, kernelDims]);
 
   const colorByFields = useMemo(() => {
     const fields = new Set<string>();
@@ -357,6 +380,8 @@ export default function DashboardRenderer({
                 globalFilters={config.globalFilters}
                 globalFilterValues={globalFilterValues}
                 onFilterChange={onGlobalFilterChange}
+                onKernelSelect={setSelectedKernelId}
+                selectedKernelId={selectedKernelId}
                 isEditing={isEditing}
                 profilingManifest={profilingManifest}
                 blobName={blobName}
@@ -364,6 +389,19 @@ export default function DashboardRenderer({
             </div>
           ))}
         </ResponsiveGridLayout>
+      )}
+
+      {/* Selected Kernel Details */}
+      {selectedKernel && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <KernelView
+            selectedKernel={selectedKernel}
+            sameShapeKernels={sameShapeKernels}
+            kernels={allKernels}
+            setSelected={setSelectedKernelId}
+            dimensions={getDimensionsForKernelType(selectedKernel.kernelType, kernelDims, selectedKernel.shape)}
+          />
+        </div>
       )}
 
       {/* Modals */}

--- a/dashboard/src/components/DashboardSections/DashboardPerformanceSection.tsx
+++ b/dashboard/src/components/DashboardSections/DashboardPerformanceSection.tsx
@@ -3,7 +3,7 @@ import { BarComparisonPlot } from "../Plots/BarPlot";
 import { BellComparisonPlot } from "../Plots/BellPlot";
 import { DashboardFilterControls } from "../FilterControls";
 import { useMemo, useState, useEffect } from "react";
-import { BarChart3, Filter, Settings, TrendingUp } from "lucide-react";
+import { AlertTriangle, BarChart3, Filter, Settings, TrendingUp } from "lucide-react";
 import type { Kernel, BackendSpec } from "../../types";
 import KernelView from "../Kernels/KernelView";
 import {
@@ -151,6 +151,7 @@ export default function DashboardPerformanceSection({
           latestBackendSpecs={latestBackendSpecs}
           isTrackerDashboard={!!trackerId}
           filterConfigs={filterConfigs}
+          kernels={kernels}
         />
       </div>
 
@@ -298,6 +299,64 @@ export default function DashboardPerformanceSection({
           />
         </div>
       )}
+
+      <FailurePanel kernels={kernels} />
+    </div>
+  );
+}
+
+function FailurePanel({ kernels }: { kernels: Kernel[] }) {
+  const failedKernels = useMemo(
+    () => kernels.filter((k) => !k.ok),
+    [kernels]
+  );
+
+  if (failedKernels.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-red-200 p-6">
+      <div className="flex items-center gap-2 mb-4">
+        <AlertTriangle className="w-5 h-5 text-red-500" />
+        <h2 className="text-lg font-semibold text-gray-800">
+          Failed Kernels
+          <span className="ml-2 text-sm font-normal text-red-600 bg-red-50 px-2 py-0.5 rounded-full">
+            {failedKernels.length}
+          </span>
+        </h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-red-50 border-b border-red-200">
+              <th className="px-4 py-2 text-left font-semibold text-gray-700">Backend</th>
+              <th className="px-4 py-2 text-left font-semibold text-gray-700">Shape</th>
+              <th className="px-4 py-2 text-left font-semibold text-gray-700">Macrotile</th>
+              <th className="px-4 py-2 text-left font-semibold text-gray-700">Error</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-red-100">
+            {failedKernels.map((k) => {
+              const macrotile =
+                k.tuningConfig?.BLOCK_M != null
+                  ? `${k.tuningConfig.BLOCK_M}×${k.tuningConfig.BLOCK_N}×${k.tuningConfig.BLOCK_K}`
+                  : "—";
+              const shapeParts = Object.entries(k.shape)
+                .map(([dim, val]) => `${dim}=${val}`)
+                .join(", ");
+              return (
+                <tr key={k.id} className="hover:bg-red-50">
+                  <td className="px-4 py-2 font-mono text-xs text-gray-700">{k.backend}</td>
+                  <td className="px-4 py-2 font-mono text-xs text-gray-600">{shapeParts}</td>
+                  <td className="px-4 py-2 font-mono text-xs text-gray-600">{macrotile}</td>
+                  <td className="px-4 py-2 font-mono text-xs text-red-700 max-w-md truncate" title={k.errorMsg}>
+                    {k.errorMsg ?? "Unknown error"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/components/DashboardSections/TrackerDashboardSection.tsx
+++ b/dashboard/src/components/DashboardSections/TrackerDashboardSection.tsx
@@ -45,6 +45,8 @@ export default function TrackerDashboardSection({
   const [aggregation, setAggregation] = useState<"avg" | "geomean">("avg");
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
+  const [selectedMacrotile, setSelectedMacrotile] = useState<string>("");
+  const [selectedKernelSource, setSelectedKernelSource] = useState<string>("");
   
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
@@ -63,6 +65,20 @@ export default function TrackerDashboardSection({
           ),
         ]);
         setRuns(runsData);
+
+        // Fetch performance timeline
+        const params = new URLSearchParams();
+        if (startDate) params.append("start_date", startDate);
+        if (endDate) params.append("end_date", endDate);
+        if (selectedMacrotile) params.append("macrotile", selectedMacrotile);
+        if (selectedKernelSource) params.append("kernel_source", selectedKernelSource);
+
+        const timelineResponse = await fetch(
+          `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/trackers/${trackerId}/performance${
+            params.toString() ? `?${params.toString()}` : ""
+          }`
+        );
+        const timelineData = await timelineResponse.json();
         setTimeline(timelineData);
       } catch (error) {
         console.error("Failed to fetch tracker data:", error);
@@ -72,7 +88,7 @@ export default function TrackerDashboardSection({
     };
 
     fetchData();
-  }, [trackerId, startDate, endDate]);
+  }, [trackerId, startDate, endDate, selectedMacrotile, selectedKernelSource]);
 
   // Sync selectedRunId with the current selectedRunBlobName
   useEffect(() => {
@@ -112,6 +128,23 @@ export default function TrackerDashboardSection({
       Object.keys(point.backends).forEach((backend) => backendSet.add(backend));
     });
     return Array.from(backendSet).sort();
+  }, [timeline]);
+
+  // Get available macrotiles and kernel sources from timeline
+  const availableMacrotiles = useMemo(() => {
+    const set = new Set<string>();
+    timeline.forEach((point) => {
+      point.availableMacrotiles?.forEach((m) => set.add(m));
+    });
+    return Array.from(set).sort();
+  }, [timeline]);
+
+  const availableKernelSources = useMemo(() => {
+    const set = new Set<string>();
+    timeline.forEach((point) => {
+      point.availableKernelSources?.forEach((s) => set.add(s));
+    });
+    return Array.from(set).sort();
   }, [timeline]);
 
   // Create/update chart when data changes
@@ -306,7 +339,7 @@ export default function TrackerDashboardSection({
             <h3 className="font-medium text-gray-700">Chart Settings</h3>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
             <div className="flex flex-col gap-2">
               <label className="font-medium text-gray-600 text-sm">
                 Metric:
@@ -358,6 +391,48 @@ export default function TrackerDashboardSection({
                 onChange={(e) => setEndDate(e.target.value)}
               />
             </div>
+
+            {availableMacrotiles.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <label className="font-medium text-gray-600 text-sm">
+                  Macrotile:
+                </label>
+                <select
+                  className="px-3 py-2 border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none text-sm"
+                  value={selectedMacrotile}
+                  onChange={(e) => {
+                    setSelectedMacrotile(e.target.value);
+                    if (e.target.value) setSelectedKernelSource("");
+                  }}
+                >
+                  <option value="">All Macrotiles</option>
+                  {availableMacrotiles.map((m) => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {availableKernelSources.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <label className="font-medium text-gray-600 text-sm">
+                  Source:
+                </label>
+                <select
+                  className="px-3 py-2 border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none text-sm"
+                  value={selectedKernelSource}
+                  onChange={(e) => {
+                    setSelectedKernelSource(e.target.value);
+                    if (e.target.value) setSelectedMacrotile("");
+                  }}
+                >
+                  <option value="">All Sources</option>
+                  {availableKernelSources.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+            )}
           </div>
         </div>
 

--- a/dashboard/src/components/DashboardSections/TrackerDashboardSection.tsx
+++ b/dashboard/src/components/DashboardSections/TrackerDashboardSection.tsx
@@ -13,7 +13,7 @@ import {
 import { Calendar, TrendingUp, Settings } from "lucide-react";
 import type { TrackerPerformancePoint, TrackerRunHistory } from "../../types";
 import { getBackendColor } from "../../utils/color";
-import { fetchTrackerRuns, fetchTrackerPerformanceTimeline } from "../../utils/github";
+import { fetchTrackerRuns } from "../../utils/github";
 
 Chart.register(
   LineController,
@@ -56,14 +56,7 @@ export default function TrackerDashboardSection({
     const fetchData = async () => {
       setIsLoading(true);
       try {
-        const [runsData, timelineData] = await Promise.all([
-          fetchTrackerRuns(trackerId),
-          fetchTrackerPerformanceTimeline(
-            trackerId,
-            startDate || undefined,
-            endDate || undefined
-          ),
-        ]);
+        const runsData = await fetchTrackerRuns(trackerId);
         setRuns(runsData);
 
         // Fetch performance timeline

--- a/dashboard/src/components/FilterControls.tsx
+++ b/dashboard/src/components/FilterControls.tsx
@@ -509,6 +509,9 @@ export function DashboardFilterControls({
       case "macrotiles":
         options = availableOptions.macrotiles;
         break;
+      case "kernelSources":
+        options = availableOptions.kernelSources;
+        break;
       default:
         options = [];
     }

--- a/dashboard/src/components/FilterControls.tsx
+++ b/dashboard/src/components/FilterControls.tsx
@@ -220,9 +220,8 @@ export function MultiSelectFilter({
         </span>
         <div className="flex gap-2">
           {options.map((option) => {
-            // Try to get spec from latest run first, then fall back to default
-            const backendSpec = isBackendsFilter 
-              ? ((latestBackendSpecs && latestBackendSpecs[option]) || getDefaultBackendSpec(option))
+            const backendSpec = isBackendsFilter
+              ? (latestBackendSpecs?.[option] || getDefaultBackendSpec(option))
               : null;
             const isSelected = selectedOptions.includes(option);
             

--- a/dashboard/src/components/FilterControls.tsx
+++ b/dashboard/src/components/FilterControls.tsx
@@ -465,6 +465,7 @@ interface DashboardFilterControlsProps {
   latestBackendSpecs?: Record<string, any>; // Backend specs from latest run indexed by backend name
   isTrackerDashboard?: boolean; // Whether this is a tracker dashboard (vs individual run)
   filterConfigs: FilterDefinition[];
+  kernels?: import("../types").Kernel[];
 }
 
 export function DashboardFilterControls({
@@ -474,12 +475,13 @@ export function DashboardFilterControls({
   latestBackendSpecs,
   isTrackerDashboard = false,
   filterConfigs: filterDefinitions,
+  kernels = [],
 }: DashboardFilterControlsProps) {
   // Build filter configurations dynamically (filter by condition, then map to UI config)
   const filterConfigs: FilterConfig[] = filterDefinitions
     .filter(
       (config: FilterDefinition) =>
-        !config.condition || config.condition(filters)
+        !config.condition || config.condition(filters, kernels)
     )
     .map((config: FilterDefinition) => {
     // Map filter keys to available options keys
@@ -503,6 +505,9 @@ export function DashboardFilterControls({
         break;
       case "variants":
         options = availableOptions.variants;
+        break;
+      case "macrotiles":
+        options = availableOptions.macrotiles;
         break;
       default:
         options = [];

--- a/dashboard/src/components/GlobalFilterBar.tsx
+++ b/dashboard/src/components/GlobalFilterBar.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react";
-import { Filter, Plus, Pencil, Trash2, Check, X } from "lucide-react";
+import { useMemo, useState, useRef, useEffect } from "react";
+import { Filter, Plus, Pencil, Trash2, Check, X, Info } from "lucide-react";
 import type { GlobalFilterConfig, GlobalFilterType } from "../types/dashboard";
 import { resolveField } from "../utils/pipeline";
 import { getValueColor } from "../utils/color";
+import { getDefaultBackendSpec } from "../utils/backendSpecs";
 
 interface GlobalFilterBarProps {
   filters: GlobalFilterConfig[];
@@ -15,6 +16,7 @@ interface GlobalFilterBarProps {
   onDeleteFilter?: (filterId: string) => void;
   /** Fields currently used as mapping.color in one or more widgets */
   colorByFields?: Set<string>;
+  latestBackendSpecs?: Record<string, any> | null;
 }
 
 const FILTER_TYPE_LABELS: Record<GlobalFilterType, string> = {
@@ -70,6 +72,7 @@ export default function GlobalFilterBar({
   onUpdateFilter,
   onDeleteFilter,
   colorByFields,
+  latestBackendSpecs,
 }: GlobalFilterBarProps) {
   const [editingFilterId, setEditingFilterId] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -140,6 +143,7 @@ export default function GlobalFilterBar({
                 rawData={rawData}
                 onChange={(val) => onChange(f.id, val)}
                 isColorCoded={colorByFields?.has(f.field) ?? false}
+                latestBackendSpecs={f.field === "backend" ? latestBackendSpecs : undefined}
               />
               {isEditing && (
                 <div className="flex gap-0.5 ml-1 mt-0.5 flex-shrink-0">
@@ -274,9 +278,23 @@ interface GlobalFilterInputProps {
   rawData: Record<string, any>[];
   onChange: (value: any) => void;
   isColorCoded?: boolean;
+  latestBackendSpecs?: Record<string, any> | null;
 }
 
-function GlobalFilterInput({ filter, value, rawData, onChange, isColorCoded = false }: GlobalFilterInputProps) {
+function GlobalFilterInput({ filter, value, rawData, onChange, isColorCoded = false, latestBackendSpecs }: GlobalFilterInputProps) {
+  const [expandedBackend, setExpandedBackend] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const isBackendFilter = filter.field === "backend";
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setExpandedBackend(null);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
   const options = useMemo(() => {
     if (filter.type === "date_range" || filter.type === "range") return [];
     const vals = rawData.map((row) => resolveField(row, filter.field));
@@ -320,25 +338,91 @@ function GlobalFilterInput({ filter, value, rawData, onChange, isColorCoded = fa
       }
     };
     return (
-      <div className="flex items-center gap-2 flex-shrink-0">
-        <span className="text-sm font-medium text-gray-600 whitespace-nowrap">
-          {filter.label}:
-        </span>
-        <div className="flex gap-1.5 flex-wrap">
-          {options.map((opt) => {
-            const active = selected.includes(opt);
-            return (
-              <button
-                key={opt}
-                onClick={() => toggle(opt)}
-                className={`px-2.5 py-1 rounded-md text-xs font-medium border transition-colors ${chipStyle(active, isColorCoded)}`}
-                style={chipInlineStyle(active, isColorCoded, opt)}
-              >
-                {opt}
-              </button>
-            );
-          })}
+      <div className="flex flex-col gap-1.5 flex-shrink-0" ref={isBackendFilter ? dropdownRef : undefined}>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-600 whitespace-nowrap">
+            {filter.label}:
+          </span>
+          <div className="flex gap-1.5 flex-wrap">
+            {options.map((opt) => {
+              const active = selected.includes(opt);
+              const backendSpec = isBackendFilter
+                ? (latestBackendSpecs?.[opt] || getDefaultBackendSpec(opt))
+                : null;
+              return (
+                <div key={opt} className="flex items-center gap-0.5">
+                  <button
+                    onClick={() => toggle(opt)}
+                    className={`px-2.5 py-1 rounded-md text-xs font-medium border transition-colors ${chipStyle(active, isColorCoded)}`}
+                    style={chipInlineStyle(active, isColorCoded, opt)}
+                  >
+                    {opt}
+                  </button>
+                  {isBackendFilter && active && backendSpec && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setExpandedBackend(expandedBackend === opt ? null : opt);
+                      }}
+                      className="p-0.5 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+                      title="Show backend details"
+                    >
+                      <Info className="w-3 h-3 text-gray-600" />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
+        {isBackendFilter && expandedBackend && (() => {
+          const backendSpec = latestBackendSpecs?.[expandedBackend] || getDefaultBackendSpec(expandedBackend);
+          if (!backendSpec) return null;
+          return (
+            <div className="ml-2 p-3 bg-gray-50 border border-gray-200 rounded-lg text-xs space-y-1.5">
+              {latestBackendSpecs?.[expandedBackend] && (
+                <div className="mb-2 pb-2 border-b border-gray-300">
+                  <span className="text-blue-600 font-semibold text-xs">✓ From This Run</span>
+                </div>
+              )}
+              <div className="flex gap-2">
+                <span className="font-semibold text-gray-600 min-w-[80px]">Name:</span>
+                <span className="text-gray-800">{backendSpec.name}</span>
+              </div>
+              {backendSpec.remoteRepository && (
+                <div className="flex gap-2">
+                  <span className="font-semibold text-gray-600 min-w-[80px]">Repository:</span>
+                  <span className="text-gray-800 font-mono text-xs">{backendSpec.remoteRepository}</span>
+                </div>
+              )}
+              {backendSpec.branch && (
+                <div className="flex gap-2">
+                  <span className="font-semibold text-gray-600 min-w-[80px]">Branch:</span>
+                  <span className="text-gray-800 font-mono text-xs">{backendSpec.branch}</span>
+                </div>
+              )}
+              {backendSpec.commitHash ? (
+                <div className="flex gap-2">
+                  <span className="font-semibold text-gray-600 min-w-[80px]">Commit:</span>
+                  <a
+                    href={`https://github.com/${backendSpec.remoteRepository}/commit/${backendSpec.commitHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:text-blue-800 font-mono text-xs underline"
+                  >
+                    {backendSpec.commitHash.substring(0, 8)}
+                  </a>
+                </div>
+              ) : (
+                <div className="flex gap-2">
+                  <span className="font-semibold text-gray-600 min-w-[80px]">Commit:</span>
+                  <span className="text-gray-500 italic text-xs">Will use latest from branch</span>
+                </div>
+              )}
+            </div>
+          );
+        })()}
       </div>
     );
   }

--- a/dashboard/src/components/GlobalFilterBar.tsx
+++ b/dashboard/src/components/GlobalFilterBar.tsx
@@ -123,8 +123,17 @@ export default function GlobalFilterBar({
       )}
 
       <div className="flex flex-wrap gap-4 items-start">
-        {filters.map((f) =>
-          isEditing && editingFilterId === f.id ? (
+        {filters.map((f) => {
+          // For select-type filters, skip rendering if there are no options in the data (unless editing)
+          const hasOptions =
+            isEditing ||
+            f.type === "range" ||
+            f.type === "date_range" ||
+            rawData.some((row) => row[f.field] != null && row[f.field] !== "");
+
+          if (!hasOptions) return null;
+
+          return isEditing && editingFilterId === f.id ? (
             <FilterForm
               key={f.id}
               initial={f}
@@ -164,8 +173,8 @@ export default function GlobalFilterBar({
                 </div>
               )}
             </div>
-          )
-        )}
+          );
+        })}
         {filters.length === 0 && !showAddForm && (
           <p className="text-xs text-gray-400 italic">
             {isEditing

--- a/dashboard/src/components/Kernels/KernelView.tsx
+++ b/dashboard/src/components/Kernels/KernelView.tsx
@@ -191,6 +191,9 @@ export default function KernelView({
                   <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
                     Macrotile
                   </th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                    Source
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
@@ -260,6 +263,19 @@ export default function KernelView({
                         {k.tuningConfig?.BLOCK_M != null
                           ? `${k.tuningConfig.BLOCK_M}×${k.tuningConfig.BLOCK_N}×${k.tuningConfig.BLOCK_K}`
                           : "—"}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-mono">
+                        {k.kernelSource ? (
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                            k.kernelSource === "wave"
+                              ? "bg-purple-100 text-purple-800"
+                              : k.kernelSource === "aiter"
+                                ? "bg-orange-100 text-orange-800"
+                                : "bg-gray-100 text-gray-600"
+                          }`}>
+                            {k.kernelSource}
+                          </span>
+                        ) : "—"}
                       </td>
                     </tr>
                   );

--- a/dashboard/src/components/Kernels/KernelView.tsx
+++ b/dashboard/src/components/Kernels/KernelView.tsx
@@ -188,6 +188,9 @@ export default function KernelView({
                   <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
                     TFLOP/s
                   </th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                    Macrotile
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
@@ -252,6 +255,11 @@ export default function KernelView({
                         }`}
                       >
                         {k.tflops.toFixed(2)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 font-mono">
+                        {k.tuningConfig?.BLOCK_M != null
+                          ? `${k.tuningConfig.BLOCK_M}×${k.tuningConfig.BLOCK_N}×${k.tuningConfig.BLOCK_K}`
+                          : "—"}
                       </td>
                     </tr>
                   );

--- a/dashboard/src/components/Modals/blocks/BackendSelector.tsx
+++ b/dashboard/src/components/Modals/blocks/BackendSelector.tsx
@@ -258,6 +258,10 @@ function CustomBackendSpecModal({ backend, onSave, onCancel }: CustomBackendSpec
   const [repository, setRepository] = useState("");
   const [branch, setBranch] = useState("main");
   const [backendParam, setBackendParam] = useState("");
+  const [rocmLibrariesRepo, setRocmLibrariesRepo] = useState("");
+  const [rocmLibrariesBranch, setRocmLibrariesBranch] = useState("");
+
+  const isWave = backend === "wave";
 
   const handleSave = () => {
     if (!repository.trim()) {
@@ -274,6 +278,13 @@ function CustomBackendSpecModal({ backend, onSave, onCancel }: CustomBackendSpec
       branch: branch.trim() || "main",
       isDefault: false,
     };
+
+    if (isWave && (rocmLibrariesRepo.trim() || rocmLibrariesBranch.trim())) {
+      customSpec.buildMeta = {
+        rocmLibrariesRepo: rocmLibrariesRepo.trim() || undefined,
+        rocmLibrariesBranch: rocmLibrariesBranch.trim() || undefined,
+      };
+    }
 
     onSave(customSpec);
   };
@@ -343,6 +354,41 @@ function CustomBackendSpecModal({ backend, onSave, onCancel }: CustomBackendSpec
               Branch name or full commit hash
             </p>
           </div>
+
+          {isWave && (
+            <div className="border-t border-gray-200 pt-4 space-y-3">
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                ROCm Libraries (optional)
+              </p>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  rocm-libraries Repository
+                </label>
+                <input
+                  type="text"
+                  value={rocmLibrariesRepo}
+                  onChange={(e) => setRocmLibrariesRepo(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none font-mono text-sm"
+                  placeholder="ROCm/rocm-libraries"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  rocm-libraries Branch
+                </label>
+                <input
+                  type="text"
+                  value={rocmLibrariesBranch}
+                  onChange={(e) => setRocmLibrariesBranch(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none font-mono text-sm"
+                  placeholder="develop"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Override the hipBLASLt build source for this spec
+                </p>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="flex gap-3 mt-6">

--- a/dashboard/src/components/Modals/blocks/BackendSelector.tsx
+++ b/dashboard/src/components/Modals/blocks/BackendSelector.tsx
@@ -260,8 +260,17 @@ function CustomBackendSpecModal({ backend, onSave, onCancel }: CustomBackendSpec
   const [backendParam, setBackendParam] = useState("");
   const [rocmLibrariesRepo, setRocmLibrariesRepo] = useState("");
   const [rocmLibrariesBranch, setRocmLibrariesBranch] = useState("");
+  const [benchmarkClass, setBenchmarkClass] = useState("WaveGemmBenchmark");
 
   const isWave = backend === "wave";
+
+  const WAVE_BENCHMARK_CLASSES = [
+    { value: "WaveGemmBenchmark", label: "WaveGemmBenchmark (f16, compile + run)" },
+    { value: "WaveMxfp4Gemm4WaveBenchmark", label: "WaveMxfp4Gemm4WaveBenchmark (mxfp4, 4-wave)" },
+    { value: "WaveMxfp4Gemm8WaveBenchmark", label: "WaveMxfp4Gemm8WaveBenchmark (mxfp4, 8-wave)" },
+    { value: "WaveMxfp4Gemm4WaveRocrollerBenchmark", label: "WaveMxfp4Gemm4WaveRocrollerBenchmark (rocroller, hipblaslt-bench)" },
+    { value: "WaveMxfp4Gemm4WaveBaselineBenchmark", label: "WaveMxfp4Gemm4WaveBaselineBenchmark (baseline, hipblaslt-bench)" },
+  ];
 
   const handleSave = () => {
     if (!repository.trim()) {
@@ -279,11 +288,14 @@ function CustomBackendSpecModal({ backend, onSave, onCancel }: CustomBackendSpec
       isDefault: false,
     };
 
-    if (isWave && (rocmLibrariesRepo.trim() || rocmLibrariesBranch.trim())) {
-      customSpec.buildMeta = {
-        rocmLibrariesRepo: rocmLibrariesRepo.trim() || undefined,
-        rocmLibrariesBranch: rocmLibrariesBranch.trim() || undefined,
-      };
+    if (isWave) {
+      customSpec.benchmarkClass = benchmarkClass;
+      if (rocmLibrariesRepo.trim() || rocmLibrariesBranch.trim()) {
+        customSpec.buildMeta = {
+          rocmLibrariesRepo: rocmLibrariesRepo.trim() || undefined,
+          rocmLibrariesBranch: rocmLibrariesBranch.trim() || undefined,
+        };
+      }
     }
 
     onSave(customSpec);
@@ -358,6 +370,26 @@ function CustomBackendSpecModal({ backend, onSave, onCancel }: CustomBackendSpec
           {isWave && (
             <div className="border-t border-gray-200 pt-4 space-y-3">
               <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                Wave Configuration
+              </p>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Benchmark Class
+                </label>
+                <select
+                  value={benchmarkClass}
+                  onChange={(e) => setBenchmarkClass(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none text-sm"
+                >
+                  {WAVE_BENCHMARK_CLASSES.map((c) => (
+                    <option key={c.value} value={c.value}>{c.label}</option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-500 mt-1">
+                  Which Python benchmark class to run for this spec
+                </p>
+              </div>
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide pt-2">
                 ROCm Libraries (optional)
               </p>
               <div>

--- a/dashboard/src/components/Plots/RooflinePlot.tsx
+++ b/dashboard/src/components/Plots/RooflinePlot.tsx
@@ -98,7 +98,8 @@ export default function RooflinePlot({
         ? "rgba(200, 200, 200, 0.3)"
         : getValueColor(groupValue).string(),
       showLine: false,
-      pointRadius: 5,
+      pointRadius: 6,
+      pointHitRadius: 12,
     }));
 
     if (selectedKernel) {
@@ -117,7 +118,8 @@ export default function RooflinePlot({
         borderColor: getValueColor(selGroup).string(),
         backgroundColor: getValueColor(selGroup).string(),
         showLine: false,
-        pointRadius: 5,
+        pointRadius: 8,
+        pointHitRadius: 12,
       });
     }
 
@@ -222,7 +224,11 @@ export default function RooflinePlot({
             },
           },
         },
-        onClick: (_, elements) => {
+        onClick: (event, elements) => {
+          // Reset zoom first so clicks always register on correct coordinates
+          if ((chartRef.current as any)?.resetZoom) {
+            (chartRef.current as any).resetZoom();
+          }
           if (elements.length > 0) {
             const datasetIndex = elements[0].datasetIndex;
             const index = elements[0].index;

--- a/dashboard/src/hooks/useKernelFilters.ts
+++ b/dashboard/src/hooks/useKernelFilters.ts
@@ -10,6 +10,7 @@ export interface FilterState {
   tags: string[];
   variants: string[];
   macrotiles: string[];
+  kernelSources: string[];
 }
 
 // Available options for each filter
@@ -21,6 +22,7 @@ export interface AvailableFilterOptions {
   tags: string[];
   variants: string[];
   macrotiles: string[];
+  kernelSources: string[];
 }
 
 // Filter configuration type
@@ -90,6 +92,15 @@ function getUniqueMacrotileForKernel(k: Kernel): string | null {
   return null;
 }
 
+function getUniqueKernelSources(kernels: Kernel[], filters: FilterState): string[] {
+  const filteredKernels = kernels.filter(
+    (k) => k.kernelType === filters.kernelType && k.machine === filters.machine
+  );
+  return Array.from(
+    new Set(filteredKernels.map((k) => k.kernelSource).filter((s): s is string => !!s))
+  ).sort();
+}
+
 function getUniqueVariants(kernels: Kernel[], filters: FilterState): string[] {
   const filteredKernels = kernels.filter(
     (k) => k.kernelType === filters.kernelType && k.machine === filters.machine
@@ -157,6 +168,13 @@ function getFilterConfigs(
       getOptions: getUniqueMacrotiles,
       condition: (filters, kernels) => getUniqueMacrotiles(kernels, filters).length > 0,
     },
+    {
+      key: "kernelSources",
+      type: "multi",
+      title: "Source",
+      getOptions: getUniqueKernelSources,
+      condition: (filters, kernels) => getUniqueKernelSources(kernels, filters).length > 0,
+    },
   ];
 }
 
@@ -214,6 +232,7 @@ function initializeFilters(
       tags: [],
       variants: [],
       macrotiles: [],
+      kernelSources: [],
     };
     const kernelTypeOptions =
       filterConfigs[0]?.getOptions([], emptyFilters) ?? [];
@@ -225,6 +244,7 @@ function initializeFilters(
       tags: [],
       variants: [],
       macrotiles: [],
+      kernelSources: [],
     };
   }
 
@@ -239,6 +259,7 @@ function initializeFilters(
     tags: [],
     variants: [],
     macrotiles: [],
+    kernelSources: [],
   };
 
   // Set initial values for all filters
@@ -285,6 +306,7 @@ export function useKernelFilters(kernels: Kernel[]) {
       tags: filterConfigs[4].getOptions(successKernels, filters),
       variants: filterConfigs[5].getOptions(successKernels, filters),
       macrotiles: filterConfigs[6].getOptions(successKernels, filters),
+      kernelSources: filterConfigs[7].getOptions(successKernels, filters),
     }),
     [successKernels, filters, filterConfigs]
   );
@@ -297,6 +319,10 @@ export function useKernelFilters(kernels: Kernel[]) {
         filters.macrotiles.length === 0 ||
         macrotile === null ||
         filters.macrotiles.includes(macrotile);
+      const kernelSourceMatch =
+        filters.kernelSources.length === 0 ||
+        !k.kernelSource ||
+        filters.kernelSources.includes(k.kernelSource);
       return (
         filters.backends.includes(k.backend) &&
         filters.dtypes.includes(k.dtype) &&
@@ -307,7 +333,8 @@ export function useKernelFilters(kernels: Kernel[]) {
           filters.variants.includes(
             k.shape.transpose || k.shape.tA + k.shape.tB
           )) &&
-        macrotileMatch
+        macrotileMatch &&
+        kernelSourceMatch
       );
     });
   }, [successKernels, filters]);

--- a/dashboard/src/hooks/useKernelFilters.ts
+++ b/dashboard/src/hooks/useKernelFilters.ts
@@ -9,6 +9,7 @@ export interface FilterState {
   dtypes: string[];
   tags: string[];
   variants: string[];
+  macrotiles: string[];
 }
 
 // Available options for each filter
@@ -19,6 +20,7 @@ export interface AvailableFilterOptions {
   dtypes: string[];
   tags: string[];
   variants: string[];
+  macrotiles: string[];
 }
 
 // Filter configuration type
@@ -28,7 +30,7 @@ export interface FilterDefinition {
   title: string;
   getOptions: (kernels: Kernel[], filters: FilterState) => string[];
   cascades?: (keyof FilterState)[];
-  condition?: (filters: FilterState) => boolean; // When to show this filter
+  condition?: (filters: FilterState, kernels: Kernel[]) => boolean; // When to show this filter
 }
 
 // Helper functions to get unique values from filtered kernels
@@ -62,6 +64,30 @@ function getUniqueTags(kernels: Kernel[], filters: FilterState): string[] {
     (k) => k.kernelType === filters.kernelType && k.machine === filters.machine
   );
   return Array.from(new Set(filteredKernels.map((k) => k.tag)));
+}
+
+function getUniqueMacrotiles(kernels: Kernel[], filters: FilterState): string[] {
+  const filteredKernels = kernels.filter(
+    (k) => k.kernelType === filters.kernelType && k.machine === filters.machine
+  );
+  const tiles = filteredKernels
+    .map((k) => {
+      const tc = k.tuningConfig;
+      if (tc?.BLOCK_M != null && tc?.BLOCK_N != null && tc?.BLOCK_K != null) {
+        return `${tc.BLOCK_M}×${tc.BLOCK_N}×${tc.BLOCK_K}`;
+      }
+      return null;
+    })
+    .filter((t): t is string => t !== null);
+  return Array.from(new Set(tiles)).sort();
+}
+
+function getUniqueMacrotileForKernel(k: Kernel): string | null {
+  const tc = k.tuningConfig;
+  if (tc?.BLOCK_M != null && tc?.BLOCK_N != null && tc?.BLOCK_K != null) {
+    return `${tc.BLOCK_M}×${tc.BLOCK_N}×${tc.BLOCK_K}`;
+  }
+  return null;
 }
 
 function getUniqueVariants(kernels: Kernel[], filters: FilterState): string[] {
@@ -122,7 +148,14 @@ function getFilterConfigs(
       type: "multi",
       title: "Transpose",
       getOptions: getUniqueVariants,
-      condition: (filters) => filters.kernelType === "gemm",
+      condition: (filters, _kernels) => filters.kernelType === "gemm",
+    },
+    {
+      key: "macrotiles",
+      type: "multi",
+      title: "Macrotile",
+      getOptions: getUniqueMacrotiles,
+      condition: (filters, kernels) => getUniqueMacrotiles(kernels, filters).length > 0,
     },
   ];
 }
@@ -180,6 +213,7 @@ function initializeFilters(
       dtypes: [],
       tags: [],
       variants: [],
+      macrotiles: [],
     };
     const kernelTypeOptions =
       filterConfigs[0]?.getOptions([], emptyFilters) ?? [];
@@ -190,6 +224,7 @@ function initializeFilters(
       dtypes: [],
       tags: [],
       variants: [],
+      macrotiles: [],
     };
   }
 
@@ -203,6 +238,7 @@ function initializeFilters(
     dtypes: [],
     tags: [],
     variants: [],
+    macrotiles: [],
   };
 
   // Set initial values for all filters
@@ -225,35 +261,43 @@ export function useKernelFilters(kernels: Kernel[]) {
     []
   );
 
+  // Only use successful kernels for deriving filter options
+  const successKernels = useMemo(() => kernels.filter((k) => k.ok), [kernels]);
+
   const [filters, setFilters] = useState<FilterState>(() =>
-    initializeFilters(kernels, filterConfigs)
+    initializeFilters(successKernels, filterConfigs)
   );
 
   // Update filters when kernels or filter configs change
   useEffect(() => {
-    if (kernels.length > 0) {
-      setFilters(initializeFilters(kernels, filterConfigs));
+    if (successKernels.length > 0) {
+      setFilters(initializeFilters(successKernels, filterConfigs));
     }
-  }, [kernels, filterConfigs]);
+  }, [successKernels, filterConfigs]);
 
   // Compute available options based on current filter state
   const availableOptions: AvailableFilterOptions = useMemo(
     () => ({
-      kernelTypes: filterConfigs[0].getOptions(kernels, filters),
-      machines: filterConfigs[1].getOptions(kernels, filters),
-      backends: filterConfigs[2].getOptions(kernels, filters),
-      dtypes: filterConfigs[3].getOptions(kernels, filters),
-      tags: filterConfigs[4].getOptions(kernels, filters),
-      variants: filterConfigs[5].getOptions(kernels, filters),
+      kernelTypes: filterConfigs[0].getOptions(successKernels, filters),
+      machines: filterConfigs[1].getOptions(successKernels, filters),
+      backends: filterConfigs[2].getOptions(successKernels, filters),
+      dtypes: filterConfigs[3].getOptions(successKernels, filters),
+      tags: filterConfigs[4].getOptions(successKernels, filters),
+      variants: filterConfigs[5].getOptions(successKernels, filters),
+      macrotiles: filterConfigs[6].getOptions(successKernels, filters),
     }),
-    [kernels, filters, filterConfigs]
+    [successKernels, filters, filterConfigs]
   );
 
   // Filter kernels based on current filter state
   const filteredKernels = useMemo(() => {
-    return kernels.filter((k) => {
+    return successKernels.filter((k) => {
+      const macrotile = getUniqueMacrotileForKernel(k);
+      const macrotileMatch =
+        filters.macrotiles.length === 0 ||
+        macrotile === null ||
+        filters.macrotiles.includes(macrotile);
       return (
-        k.ok &&
         filters.backends.includes(k.backend) &&
         filters.dtypes.includes(k.dtype) &&
         filters.tags.includes(k.tag) &&
@@ -262,15 +306,16 @@ export function useKernelFilters(kernels: Kernel[]) {
         (k.kernelType !== "gemm" ||
           filters.variants.includes(
             k.shape.transpose || k.shape.tA + k.shape.tB
-          ))
+          )) &&
+        macrotileMatch
       );
     });
-  }, [kernels, filters]);
+  }, [successKernels, filters]);
 
   // Update function with cascading logic
   const updateFilter = (key: keyof FilterState, value: any) => {
     setFilters((prevFilters) =>
-      computeNewFilterState(prevFilters, key, value, kernels, filterConfigs)
+      computeNewFilterState(prevFilters, key, value, successKernels, filterConfigs)
     );
   };
 

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -31,6 +31,7 @@ export default function Dashboard() {
   const [tracker, setTracker] = useState<Tracker | null>(null);
   const [selectedRunBlobName, setSelectedRunBlobName] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [runBackendSpecs, setRunBackendSpecs] = useState<Record<string, any> | null>(null);
 
   const [modularConfig, setModularConfig] = useState<DashboardConfig>(DEFAULT_MODULAR_CONFIG);
   const [globalFilterValues, setGlobalFilterValues] = useState<Record<string, any>>({});
@@ -81,7 +82,6 @@ export default function Dashboard() {
         const runIdOrBlobName = location.pathname.split('/').pop();
         setSelectedRunBlobName(runIdOrBlobName || null);
 
-        // Fetch run data to get backendSpecs
         if (runIdOrBlobName) {
           try {
             const response = await fetch(
@@ -89,13 +89,9 @@ export default function Dashboard() {
             );
             const data = await response.json();
             const runs = data.runs || [];
-
-            // Find matching run by blobName or ID
-            const item = runs.find((item: any) =>
-              item.run?.blobName === runIdOrBlobName || item.run?._id === runIdOrBlobName
+            const item = runs.find((r: any) =>
+              r.run?.blobName === runIdOrBlobName || r.run?._id === runIdOrBlobName
             );
-
-            // Extract backendSpecs from trigger metadata
             if (item?.trigger?.metadata?.backendSpecs) {
               const specsMap: Record<string, any> = {};
               item.trigger.metadata.backendSpecs.forEach((spec: any) => {
@@ -105,7 +101,7 @@ export default function Dashboard() {
               setRunBackendSpecs(specsMap);
             }
           } catch (error) {
-            console.error("Failed to fetch run data:", error);
+            console.error("Failed to fetch run backend specs:", error);
           }
         }
 
@@ -192,6 +188,7 @@ export default function Dashboard() {
             isTrackerDashboard={isTrackerDashboard}
             profilingManifest={profilingManifest}
             blobName={selectedRunBlobName}
+            latestBackendSpecs={runBackendSpecs}
           />
         )}
         

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -114,7 +114,17 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (selectedRunBlobName) {
-      fetchData(selectedRunBlobName).then(setKernels);
+      fetchData(selectedRunBlobName).then((data) => {
+        // Flatten macrotile from tuningConfig into a top-level field for global filter use
+        const enriched = data.map((k: any) => {
+          const tc = k.tuningConfig;
+          if (tc?.BLOCK_M != null && tc?.BLOCK_N != null && tc?.BLOCK_K != null) {
+            return { ...k, macrotile: `${tc.BLOCK_M}×${tc.BLOCK_N}×${tc.BLOCK_K}` };
+          }
+          return k;
+        });
+        setKernels(enriched);
+      });
       fetchProfilingManifest(selectedRunBlobName)
         .then(setProfilingManifest)
         .catch(() => setProfilingManifest(null));

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -80,6 +80,35 @@ export default function Dashboard() {
         setIsTrackerDashboard(false);
         const runIdOrBlobName = location.pathname.split('/').pop();
         setSelectedRunBlobName(runIdOrBlobName || null);
+
+        // Fetch run data to get backendSpecs
+        if (runIdOrBlobName) {
+          try {
+            const response = await fetch(
+              `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/runs?page=1&page_size=1000&completed_only=true`
+            );
+            const data = await response.json();
+            const runs = data.runs || [];
+
+            // Find matching run by blobName or ID
+            const item = runs.find((item: any) =>
+              item.run?.blobName === runIdOrBlobName || item.run?._id === runIdOrBlobName
+            );
+
+            // Extract backendSpecs from trigger metadata
+            if (item?.trigger?.metadata?.backendSpecs) {
+              const specsMap: Record<string, any> = {};
+              item.trigger.metadata.backendSpecs.forEach((spec: any) => {
+                const key = spec.backendParam || spec.backend;
+                specsMap[key] = spec;
+              });
+              setRunBackendSpecs(specsMap);
+            }
+          } catch (error) {
+            console.error("Failed to fetch run data:", error);
+          }
+        }
+
         setIsLoading(false);
       }
     };

--- a/dashboard/src/pages/Tracking.tsx
+++ b/dashboard/src/pages/Tracking.tsx
@@ -99,6 +99,7 @@ export default function Tracking() {
         dashboardName: config.dashboardName,
         tags: config.kernelSelection.tags || [],
         backends: config.backends,
+        backendSpecs: config.backendSpecs,
         machine: config.machine,
         schedule: config.schedule,
         branch: config.branch,

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -19,6 +19,7 @@ export interface BackendSpec {
   commitHash?: string; // specific commit, or use latest if not specified
   isDefault?: boolean; // whether this is the default spec for this backend
   parentSpecId?: string; // if this is a variant, reference to the parent spec (inherits repo/branch)
+  benchmarkClass?: string; // Python class name to use for this backend (e.g., "WaveMxfp4Gemm4WaveBenchmark")
   buildMeta?: {
     rocmLibrariesRepo?: string; // e.g., "ROCm/rocm-libraries" — overrides default for this spec
     rocmLibrariesBranch?: string; // e.g., "develop"

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -19,6 +19,10 @@ export interface BackendSpec {
   commitHash?: string; // specific commit, or use latest if not specified
   isDefault?: boolean; // whether this is the default spec for this backend
   parentSpecId?: string; // if this is a variant, reference to the parent spec (inherits repo/branch)
+  buildMeta?: {
+    rocmLibrariesRepo?: string; // e.g., "ROCm/rocm-libraries" — overrides default for this spec
+    rocmLibrariesBranch?: string; // e.g., "develop"
+  };
 }
 
 // Runtime configuration for kernels

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -47,6 +47,7 @@ export interface Kernel {
   tuningConfig: Record<string, any> | undefined | null;
   ok: boolean;
   errorMsg?: string;
+  kernelSource?: string; // "wave", "aiter", or null if unknown
 }
 
 export interface KernelConfig {
@@ -257,6 +258,8 @@ export interface TrackerPerformancePoint {
     numKernels: number;
   }>;
   backendSpecs?: BackendSpec[]; // Backend specifications with commit hashes
+  availableMacrotiles?: string[]; // e.g. ["256x192x256", "256x224x256"]
+  availableKernelSources?: string[]; // e.g. ["wave", "aiter", "rocroller"]
 }
 
 export interface Tracker {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -45,7 +45,8 @@ export interface Kernel {
   tflops: number;
   shape: Record<string, any>;
   tuningConfig: Record<string, any> | undefined | null;
-  ok: string;
+  ok: boolean;
+  errorMsg?: string;
 }
 
 export interface KernelConfig {

--- a/dashboard/src/types/dashboard.ts
+++ b/dashboard/src/types/dashboard.ts
@@ -161,6 +161,8 @@ export interface WidgetProps {
   data: Record<string, any>[];
   globalFilterValues: Record<string, any>;
   onFilterChange?: (filterId: string, value: any) => void;
+  onKernelSelect?: (kernelId: string | null) => void;
+  selectedKernelId?: string | null;
   isEditing?: boolean;
   profilingManifest?: Record<string, any> | null;
   blobName?: string | null;

--- a/dashboard/src/utils/backendSpecs.ts
+++ b/dashboard/src/utils/backendSpecs.ts
@@ -66,6 +66,15 @@ export const VARIANT_BACKEND_SPECS: BackendSpec[] = [
     parentSpecId: "wave-default",
   },
   {
+    id: "wave-4wave-baseline",
+    name: "Wave 4-wave (baseline)",
+    backend: "wave",
+    backendParam: "wave_4wave_baseline",
+    remoteRepository: "panditsa/wave",
+    branch: "4waveasm-256x192x256",
+    parentSpecId: "wave-default",
+  },
+  {
     id: "wave-4wave-rocroller",
     name: "Wave 4-wave (rocroller)",
     backend: "wave",

--- a/dashboard/src/utils/backendSpecs.ts
+++ b/dashboard/src/utils/backendSpecs.ts
@@ -84,7 +84,7 @@ export const VARIANT_BACKEND_SPECS: BackendSpec[] = [
     backend: "wave",
     backendParam: "wave_4wave_rocroller",
     remoteRepository: "panditsa/wave",
-    branch: "reduce_reg_pres",
+    branch: "4waveasm-256x192x256",
     parentSpecId: "wave-default",
     buildMeta: {
       rocmLibrariesRepo: "suryajasper/rocm-libraries",

--- a/dashboard/src/utils/backendSpecs.ts
+++ b/dashboard/src/utils/backendSpecs.ts
@@ -73,6 +73,10 @@ export const VARIANT_BACKEND_SPECS: BackendSpec[] = [
     remoteRepository: "panditsa/wave",
     branch: "4waveasm-256x192x256",
     parentSpecId: "wave-default",
+    buildMeta: {
+      rocmLibrariesRepo: "ROCm/rocm-libraries",
+      rocmLibrariesBranch: "develop",
+    },
   },
   {
     id: "wave-4wave-rocroller",

--- a/dashboard/src/utils/backendSpecs.ts
+++ b/dashboard/src/utils/backendSpecs.ts
@@ -86,6 +86,10 @@ export const VARIANT_BACKEND_SPECS: BackendSpec[] = [
     remoteRepository: "panditsa/wave",
     branch: "reduce_reg_pres",
     parentSpecId: "wave-default",
+    buildMeta: {
+      rocmLibrariesRepo: "suryajasper/rocm-libraries",
+      rocmLibrariesBranch: "wave-mxfp4-testing",
+    },
   },
   {
     id: "wave-8wave-rocroller",

--- a/dashboard/src/utils/backendSpecs.ts
+++ b/dashboard/src/utils/backendSpecs.ts
@@ -70,8 +70,8 @@ export const VARIANT_BACKEND_SPECS: BackendSpec[] = [
     name: "Wave 4-wave (baseline)",
     backend: "wave",
     backendParam: "wave_4wave_baseline",
-    remoteRepository: "panditsa/wave",
-    branch: "4waveasm-256x192x256",
+    remoteRepository: "iree-org/wave",
+    branch: "main",
     parentSpecId: "wave-default",
     buildMeta: {
       rocmLibrariesRepo: "ROCm/rocm-libraries",

--- a/dashboard/src/utils/pipeline.ts
+++ b/dashboard/src/utils/pipeline.ts
@@ -61,6 +61,8 @@ function matchOperator(
     case "lte":
       return fieldValue <= target;
     case "in":
+      // null/undefined field values pass through (field absent on this row)
+      if (fieldValue == null) return true;
       return Array.isArray(target) && target.includes(fieldValue);
     case "not_in":
       return Array.isArray(target) && !target.includes(fieldValue);

--- a/dashboard/src/widgets/RooflineWidget.tsx
+++ b/dashboard/src/widgets/RooflineWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import type { WidgetProps } from "../types/dashboard";
 import type { Kernel } from "../types";
@@ -9,12 +9,13 @@ import RocprofTooltip from "../components/RocprofTooltip";
 export default function RooflineWidget({
   config,
   data,
+  onKernelSelect,
+  selectedKernelId,
   profilingManifest,
   blobName,
 }: WidgetProps) {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
   const kernels = data as unknown as Kernel[];
-  const selectedKernel = kernels.find((k) => k.id === selectedId);
+  const selectedKernel = kernels.find((k) => k.id === selectedKernelId);
   const navigate = useNavigate();
 
   const selectedDumpKey = useMemo(() => {
@@ -25,20 +26,20 @@ export default function RooflineWidget({
   const handleKernelClick = useCallback(
     (kernelId: string | null) => {
       if (!kernelId) {
-        setSelectedId(null);
+        onKernelSelect?.(null);
         return;
       }
 
-      if (selectedId === kernelId && selectedDumpKey && blobName) {
+      if (selectedKernelId === kernelId && selectedDumpKey && blobName) {
         navigate(
           `/trace/${encodeURIComponent(blobName)}?dumpKey=${encodeURIComponent(selectedDumpKey)}&kernel=${encodeURIComponent(selectedKernel!.name)}`
         );
         return;
       }
 
-      setSelectedId(kernelId);
+      onKernelSelect?.(kernelId);
     },
-    [selectedId, selectedDumpKey, blobName, selectedKernel, navigate]
+    [selectedKernelId, selectedDumpKey, blobName, selectedKernel, navigate, onKernelSelect]
   );
 
   if (kernels.length === 0) {

--- a/dashboard/src/widgets/WidgetRenderer.tsx
+++ b/dashboard/src/widgets/WidgetRenderer.tsx
@@ -9,6 +9,8 @@ interface WidgetRendererProps {
   globalFilters: GlobalFilterConfig[];
   globalFilterValues: Record<string, any>;
   onFilterChange?: (filterId: string, value: any) => void;
+  onKernelSelect?: (kernelId: string | null) => void;
+  selectedKernelId?: string | null;
   isEditing?: boolean;
   profilingManifest?: Record<string, any> | null;
   blobName?: string | null;
@@ -20,6 +22,8 @@ export default function WidgetRenderer({
   globalFilters,
   globalFilterValues,
   onFilterChange,
+  onKernelSelect,
+  selectedKernelId,
   isEditing = false,
   profilingManifest,
   blobName,
@@ -58,6 +62,8 @@ export default function WidgetRenderer({
     data: transformedData,
     globalFilterValues,
     onFilterChange,
+    onKernelSelect,
+    selectedKernelId,
     isEditing,
     profilingManifest: config.rocprofEnabled ? profilingManifest : undefined,
     blobName: config.rocprofEnabled ? blobName : undefined,

--- a/dashboard/src/widgets/defaults.ts
+++ b/dashboard/src/widgets/defaults.ts
@@ -122,5 +122,17 @@ export const DEFAULT_MODULAR_CONFIG: DashboardConfig = {
       label: "Tag",
       type: "multi",
     },
+    {
+      id: "gf-macrotile",
+      field: "macrotile",
+      label: "Macrotile",
+      type: "multi",
+    },
+    {
+      id: "gf-kernelSource",
+      field: "kernelSource",
+      label: "Source",
+      type: "multi",
+    },
   ],
 };


### PR DESCRIPTION
- Backend specs UI: Replaced single-variant dropdown with multi-select checklist in BackendSelector, allowing multiple wave variants to be selected simultaneously (e.g., 4-wave + 8-wave rocroller)
  - backendParam support: Added backendParam field to BackendSpec type, enabling CLI parameter names that differ from the backend name (e.g., wave_4wave_rocroller). Modals now use backendParam || backend for backward compatibility
  - Tracker bug fixes: Fixed backendSpecs being dropped when loading/saving trackers, and fixed trigger_service.py to derive selected_backend from backendSpecs with backendParam priority
  - Workflow: Added "Parse Backend Specs" step to extract per-variant wave/rocm-libraries repo+branch from backend specs gist, with fallback to pr_repository/pr_branch
  - New variant specs: Added wave 4-wave rocroller (panditsa/wave@4waveasm-256x192x256) and 8-wave rocroller (adedespirlet/wave@8wavepingpong) specs